### PR TITLE
ceil instead of round ntracks_val

### DIFF
--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -453,7 +453,7 @@ namespace locust
 
         std::default_random_engine generator(random_seed_val);
         std::exponential_distribution<double> ntracks_distribution(1./fNTracksMean);
-        ntracks_val = round(ntracks_distribution(generator));
+        ntracks_val = ceil(ntracks_distribution(generator));
         if ( ntracks_val == 0 ) // if we rounded to 0, let's simulate at least one tracks
         {
             ntracks_val = 1;


### PR DESCRIPTION
The number of tracks per event in the data follows an exponential distribution.
So far the number of tracks per event in the fake track generator was calculated by rounding a sample from an exponential distribution. To avoid simulations with zero tracks per event, the number of tracks is set to 1 if the rounded sample is zero. 

But this results in a massive distortion of the ntracks per event distribution after reconstruction. To fix this it was suggested to always add 1 after rounding and therefore shift the entire distribution up. However, that would not complete fix the issue, because the range that is rounded to 1 is twice as large as the range that is rounded to zero.
I suggest that instead of rounding we take the ceil of the random sample. This way, the distribution is still shifted up, there wouldn't be any events with zero tracks and the problem of non-equal rounding ranges is avoided.

Question:
The configurable parameter 'ntracks-mean' is not actually the mean track length (neither before nor after this pull request). Should we rename it?
