### PR TITLE
Feature/multiple records per acq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 1.9.5)
+project( locust_mc VERSION 1.9.6)
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )
 include( PackageBuilder )

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM project8/p8compute_dependencies:v0.4.0 as locust_common
 ARG build_type=Release
 ENV LOCUST_BUILD_TYPE=$build_type
 
-ENV LOCUST_TAG=v1.9.5
+ENV LOCUST_TAG=v1.9.6
 ENV LOCUST_BUILD_PREFIX=/usr/local/p8/locust/$LOCUST_TAG
 
 RUN mkdir -p $LOCUST_BUILD_PREFIX &&\

--- a/Source/Core/LMCEggWriter.cc
+++ b/Source/Core/LMCEggWriter.cc
@@ -173,9 +173,6 @@ namespace locust
     {
 
 
-        //static bool t_is_new_acq = true;
-
-
         if( f_state != kWriting && f_state != kPrepared )
         {
             LERROR( lmclog, "Egg file must be opened before writing records" );
@@ -209,7 +206,7 @@ namespace locust
         ++f_record_id;
         f_record_time += f_record_length;
 
-        bool t_return = f_stream->WriteRecord( f_is_new_acq ); // pls had to edit false to true
+        bool t_return = f_stream->WriteRecord( f_is_new_acq );
         f_is_new_acq = false;
         return t_return;
     }

--- a/Source/Core/LMCEggWriter.cc
+++ b/Source/Core/LMCEggWriter.cc
@@ -34,6 +34,7 @@ namespace locust
             f_record_id( 0 ),
             f_record_time( 0 ),
             f_record_n_bytes( 0 ),
+            f_is_new_acq( true ),
             f_monarch( NULL ),
             f_stream( NULL ),
             f_record( NULL ),
@@ -172,7 +173,7 @@ namespace locust
     {
 
 
-        static bool t_is_new_acq = true;
+        //static bool t_is_new_acq = true;
 
 
         if( f_state != kWriting && f_state != kPrepared )
@@ -208,8 +209,8 @@ namespace locust
         ++f_record_id;
         f_record_time += f_record_length;
 
-        bool t_return = f_stream->WriteRecord( true ); // pls had to edit false to true
-        t_is_new_acq = false;
+        bool t_return = f_stream->WriteRecord( f_is_new_acq ); // pls had to edit false to true
+        f_is_new_acq = false;
         return t_return;
     }
 

--- a/Source/Core/LMCEggWriter.hh
+++ b/Source/Core/LMCEggWriter.hh
@@ -70,6 +70,7 @@ namespace locust
             mv_accessible_noset( monarch3::RecordIdType, record_id );
             mv_accessible_noset( monarch3::TimeType, record_time );
             mv_accessible_noset( uint64_t, record_n_bytes );
+            mv_accessible_noset( bool, is_new_acq );
 
         private:
             monarch3::Monarch3* f_monarch;

--- a/Source/Generators/LMCGaussianNoiseGenerator.cc
+++ b/Source/Generators/LMCGaussianNoiseGenerator.cc
@@ -86,7 +86,7 @@ namespace locust
 
     void GaussianNoiseGenerator::SetMean( double aMean )
     {
-        SetMeanAndSigma( aMean, fSigma );
+        fMean = aMean;
         return;
     }
 
@@ -97,13 +97,13 @@ namespace locust
 
     void GaussianNoiseGenerator::SetSigma( double aSigma )
     {
-        SetMeanAndSigma( fMean, aSigma );
+        fSigma = aSigma;
         return;
     }
 
-    void GaussianNoiseGenerator::SetMeanAndSigma( double aMean, double aSigma )
+    void GaussianNoiseGenerator::SetMeanAndSigma( double aMean, double aSigma, double aSampledSigma )
     {
-        fNormDist = std::normal_distribution< double >( aMean, aSigma );
+        fNormDist = std::normal_distribution< double >( aMean, aSampledSigma );
         fUniDist = std::uniform_real_distribution< double >(0.,360.);
         fMean = aMean;
         fSigma = aSigma;
@@ -143,7 +143,7 @@ namespace locust
     bool GaussianNoiseGenerator::DoGenerateTime( Signal* aSignal )
     {
 
-    	SetMeanAndSigma( fMean, fSigma * sqrt(fAcquisitionRate * 1.e6) );
+    	SetMeanAndSigma( fMean, fSigma, fSigma * sqrt(fAcquisitionRate * 1.e6) );
 
         double gain=1.;
         const unsigned nchannels = fNChannels;

--- a/Source/Generators/LMCGaussianNoiseGenerator.hh
+++ b/Source/Generators/LMCGaussianNoiseGenerator.hh
@@ -57,7 +57,7 @@ namespace locust
             double GetSigma() const;
             void SetSigma( double aSigma );
 
-            void SetMeanAndSigma( double aMean, double aSigma );
+            void SetMeanAndSigma( double aMean, double aSigma, double aSampledSigma);
 
             Signal::State GetDomain() const;
             void SetDomain( Signal::State aDomain );


### PR DESCRIPTION
At the moment, every record is written to a new acquisition.
With these changes, the records in egg files will contain a single acquisition with n-records.