### PR TITLE
Feature/butterworthfix

### DIFF
--- a/Source/Generators/LMCButterworthLPFGenerator.cc
+++ b/Source/Generators/LMCButterworthLPFGenerator.cc
@@ -2,7 +2,7 @@
  * LMCButterworthLPFGenerator.cc
  *
  *  Created on: Sept 9, 2016
- *      Author: plslocum after nsoblath
+ *      Author: plslocum
  */
 
 #include "LMCButterworthLPFGenerator.hh"
@@ -95,8 +95,10 @@ namespace locust
 
     bool ButterworthLPFGenerator::DoGenerateTime( Signal* aSignal )
     {
-        // 8th order Butterworth filter with wc = 70.e6 Hz, 100X attenuation at 95 MHz, fs=200 MHz.
+        const unsigned nchannels = fNChannels;
 
+        for (int ch=0; ch<nchannels; ch++)
+        {
         for( unsigned IQindex = 0; IQindex < 2; IQindex++ )
         {
 
@@ -106,7 +108,7 @@ namespace locust
         for( unsigned index = 0; index < aSignal->TimeSize(); ++index ) // initialize
           {
           FilteredMagnitude[index] = 0.;
-          RawMagnitude[index] = aSignal->SignalTimeComplex()[index][IQindex];
+          RawMagnitude[index] = aSignal->SignalTimeComplex()[ch*aSignal->TimeSize() + index][IQindex];
           }
 
         for( unsigned index = fN; index < aSignal->TimeSize(); ++index )
@@ -130,13 +132,14 @@ namespace locust
 
         for( unsigned index = 0; index < aSignal->TimeSize(); ++index )  // apply filter
           {
-          aSignal->SignalTimeComplex()[index][IQindex] = FilteredMagnitude[index];
+          aSignal->SignalTimeComplex()[ch*aSignal->TimeSize() + index][IQindex] = FilteredMagnitude[index];
           }
 
         delete FilteredMagnitude;
         delete RawMagnitude;
 
         } // IQindex
+        } // nchannels
 
 
 

--- a/Source/Generators/LMCButterworthLPFGenerator.cc
+++ b/Source/Generators/LMCButterworthLPFGenerator.cc
@@ -19,7 +19,11 @@ namespace locust
 
     ButterworthLPFGenerator::ButterworthLPFGenerator( const std::string& aName ) :
         Generator( aName ),
-        fDoGenerateFunc( &ButterworthLPFGenerator::DoGenerateTime )
+        fDoGenerateFunc( &ButterworthLPFGenerator::DoGenerateTime ),
+		fFIRa( 0. ),
+		fFIRb( 0. ),
+		fN( 0. ),
+		fM( 0. )
     {
         fRequiredSignalState = Signal::kTime;
     }
@@ -28,9 +32,53 @@ namespace locust
     {
     }
 
+    bool ButterworthLPFGenerator::SetCoefficients()
+    {
+
+    	fN = 8;
+    	fM = 8;
+    	fFIRa.resize(fN+1);
+    	fFIRb.resize(fN+1);
+
+        // raw coefficients from numerator of G(z) in Mathematica, starting with Butterworth polynomials.
+        fFIRa[0] = 12.675;
+        fFIRa[1] = 101.4;
+        fFIRa[2] = 354.9;
+        fFIRa[3] = 709.8;
+        fFIRa[4] = 887.25;
+        fFIRa[5] = 709.8;
+        fFIRa[6] = 354.9;
+        fFIRa[7] = 101.4;
+        fFIRa[8] = 12.675;
+
+        // raw coefficients from denominator of G(z) in Mathematica, starting with Butterworth polynomials.
+        fFIRb[0] = 160.698;
+        fFIRb[1] = -511.67;
+        fFIRb[2] = -832.628;
+        fFIRb[3] = -837.901;
+        fFIRb[4] = -561.456;
+        fFIRb[5] = -252.64;
+        fFIRb[6] = -73.9998;
+        fFIRb[7] = -12.8136;
+        fFIRb[8] = -1.;
+
+
+        double norm = fFIRb[0];
+        for (int i=0; i<fN+1; i++)
+          {
+          fFIRa[i] /= norm;
+          fFIRb[i] /= norm;
+          }
+
+    	return true;
+    }
+
     bool ButterworthLPFGenerator::Configure( const scarab::param_node& aParam )
     {
-        return true;
+
+        SetCoefficients();
+
+    	return true;
     }
 
     void ButterworthLPFGenerator::Accept( GeneratorVisitor* aVisitor ) const
@@ -49,74 +97,49 @@ namespace locust
     {
         // 8th order Butterworth filter with wc = 70.e6 Hz, 100X attenuation at 95 MHz, fs=200 MHz.
 
-        double* ai = new double[20];
-        double* bi = new double[20];
-        int N = 8;  // 8th order digital filter.
-        int M = 8;
-
-        // raw coefficients from numerator of G(z) in Mathematica, starting with Butterworth polynomials.
-        ai[0] = 12.675;
-        ai[1] = 101.4;
-        ai[2] = 354.9;
-        ai[3] = 709.8;
-        ai[4] = 887.25;
-        ai[5] = 709.8;
-        ai[6] = 354.9;
-        ai[7] = 101.4;
-        ai[8] = 12.675;
-
-        // raw coefficients from denominator of G(z) in Mathematica, starting with Butterworth polynomials.
-        bi[0] = 160.698;
-        bi[1] = -511.67;
-        bi[2] = -832.628;
-        bi[3] = -837.901;
-        bi[4] = -561.456;
-        bi[5] = -252.64;
-        bi[6] = -73.9998;
-        bi[7] = -12.8136;
-        bi[8] = -1.;
-
-
-        double norm = bi[0];
-        for (int i=0; i<N+1; i++)
-        {
-            ai[i] /= norm;
-            bi[i] /= norm;
-        }
-
-        for (int i=0; i<N+1; i++)
-            printf("ai[%d] is %f and bi[%d] is %f\n", i, ai[i], i, bi[i]);
-
-        double FIR_component = 0.;
-        double IIR_component = 0.;
-        double *FilteredSignal = new double[aSignal->TimeSize()]; // temporary signal.
-        for( unsigned index = 0; index < aSignal->TimeSize(); ++index )
-            FilteredSignal[index] = 0.;
-
-
-        for( unsigned index = N; index < aSignal->TimeSize(); ++index )
+        for( unsigned IQindex = 0; IQindex < 2; IQindex++ )
         {
 
-            FIR_component = 0.;
-            IIR_component = 0.;
+        double* FilteredMagnitude = new double[aSignal->TimeSize()]; // temporary signal.
+        double* RawMagnitude = new double[aSignal->TimeSize()];  // incoming signal.
 
-            for (int i=0; i<N+1; i++)
-                FIR_component += ai[i]*aSignal->SignalTime()[index-i];
-            for (int i=1; i<M+1; i++)
-                IIR_component += bi[i]*FilteredSignal[index-i];
+        for( unsigned index = 0; index < aSignal->TimeSize(); ++index ) // initialize
+          {
+          FilteredMagnitude[index] = 0.;
+          RawMagnitude[index] = aSignal->SignalTimeComplex()[index][IQindex];
+          }
 
-            FilteredSignal[index] = FIR_component + IIR_component;
-            //      printf("FilteredSignal[%d] is %g\n", index, FilteredSignal[index]); getchar();
-        }
+        for( unsigned index = fN; index < aSignal->TimeSize(); ++index )
+          {
 
-        for( unsigned index = N+1; index < aSignal->TimeSize(); ++index )
-        {
-            //      printf("FilteredSignal[%d] is %g\n", index, FilteredSignal[index]); getchar();
-            aSignal->SignalTime()[index] = FilteredSignal[index];
-        }
+          double FIR_component = 0.;
+          double IIR_component = 0.;
+
+          for (int i=0; i<fN+1; i++)
+            {
+            FIR_component += fFIRa[i]*RawMagnitude[index-i];
+            }
+          for (int i=1; i<fM+1; i++)
+            {
+            IIR_component += fFIRb[i]*FilteredMagnitude[index-i];
+            }
+
+          FilteredMagnitude[index] = FIR_component + IIR_component;
+
+          }
+
+        for( unsigned index = 0; index < aSignal->TimeSize(); ++index )  // apply filter
+          {
+          aSignal->SignalTimeComplex()[index][IQindex] = FilteredMagnitude[index];
+          }
+
+        delete FilteredMagnitude;
+        delete RawMagnitude;
+
+        } // IQindex
 
 
-        delete [] FilteredSignal;
+
         return true;
     }
 

--- a/Source/Generators/LMCButterworthLPFGenerator.hh
+++ b/Source/Generators/LMCButterworthLPFGenerator.hh
@@ -20,9 +20,10 @@ namespace locust
      @brief Apply digital low pass filter to signal.
 
      @details
-     This is an 8th order Butterworth low-pass filter defined by coefficients that are
-     presently hard-coded in LMCButterworthLPFGenerator::SetCoefficients().  The coefficients
-     are calculated in the Mathematica notebook as in
+     This is an 8th order Butterworth low-pass filter that operates only in the time domain,
+     defined by coefficients that are presently hard-coded in
+     LMCButterworthLPFGenerator::SetCoefficients().  The coefficients are calculated in the
+     Mathematica notebook as in
      https://github.com/project8/scripts/blob/master/slocum/RFButterworth8thOrder.nb .
 
      To check the output of this filter, use the following two generators:  "gaussian-noise"
@@ -30,7 +31,7 @@ namespace locust
      should be clearly visible.
 
      This generator can only be used after decimation.  It does not stop frequency aliasing.
-     The filter behavior is wc = 70.e6 Hz, 100X attenuation at 95 MHz, fs=200 MHz.
+     The present filter behavior is wc = 70.e6 Hz, 100X attenuation at 95 MHz, fs=200 MHz.
 
      If a Butterworth filter is desired for use before decimation, then the filter coefficients
      would need to be recalculated at the faster pre-decimation sampling frequency.  The filtering

--- a/Source/Generators/LMCButterworthLPFGenerator.hh
+++ b/Source/Generators/LMCButterworthLPFGenerator.hh
@@ -2,7 +2,7 @@
  * LMCButterworthLPFGenerator.hh
  *
  *  Created on: 29 January 2015
- *      Author: plslocum after nsoblath
+ *      Author: plslocum
  */
 
 #ifndef LMCBUTTERWORTHLPFGENERATOR_HH_
@@ -15,12 +15,27 @@ namespace locust
 
     /*!
      @class ButterworthLPFGenerator
-     @author P. L. Slocum after N. S. Oblath
+     @author P. L. Slocum
 
      @brief Apply digital low pass filter to signal.
 
      @details
-     Can operate in frequency or time space, but only the frequency version will have any effect on the signal.
+     This is an 8th order Butterworth low-pass filter defined by coefficients that are
+     presently hard-coded in LMCButterworthLPFGenerator::SetCoefficients().  The coefficients
+     are calculated in the Mathematica notebook as in
+     https://github.com/project8/scripts/blob/master/slocum/RFButterworth8thOrder.nb .
+
+     To check the output of this filter, use the following two generators:  "gaussian-noise"
+     followed by "butterworth-lpf".  The attenuation of the noise power at high frequencies
+     should be clearly visible.
+
+     This generator can only be used after decimation.  It does not stop frequency aliasing.
+     The filter behavior is wc = 70.e6 Hz, 100X attenuation at 95 MHz, fs=200 MHz.
+
+     If a Butterworth filter is desired for use before decimation, then the filter coefficients
+     would need to be recalculated at the faster pre-decimation sampling frequency.  The filtering
+     would be done on aSignal->LongSignalTimeComplex() instead of aSignal->SignalTimeComplex().
+     This would likely require a new generator, called LMCFastButterworthLPFGenerator, or similar.
 
      Configuration name: "butterworth-lpf"
 
@@ -32,6 +47,7 @@ class ButterworthLPFGenerator : public Generator
             ButterworthLPFGenerator( const std::string& aName = "butterworth-lpf" );
             virtual ~ButterworthLPFGenerator();
 
+            bool SetCoefficients();
             bool Configure( const scarab::param_node& aNode );
 
             void Accept( GeneratorVisitor* aVisitor ) const;
@@ -41,8 +57,12 @@ class ButterworthLPFGenerator : public Generator
 
             bool DoGenerateTime( Signal* aSignal );
             bool DoGenerateFreq( Signal* aSignal );
-
             bool (ButterworthLPFGenerator::*fDoGenerateFunc)( Signal* aSignal );
+
+            double fN;
+            double fM;
+            std::vector<double> fFIRa;
+            std::vector<double> fFIRb;
     };
 
 } /* namespace locust */


### PR DESCRIPTION
The Butterworth filter is now compatible with complex multichannel signals.  The coefficients are  std::vector and are calculated only once.  The documentation is updated with a reference to the Mathematica notebook used to calculate the coefficients. 

These changes are in reference to https://github.com/project8/locust_mc/issues/79 .