### PR TITLE
adds waveguide coupling to MC truth

### DIFF
--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -632,7 +632,7 @@ namespace locust
         aTrack.TrackLength = fTrackLength;
         aTrack.EndTime = aTrack.StartTime + aTrack.TrackLength;
         aTrack.LOFrequency = fLO_frequency;
-        aTrack.TrackPower = fSignalPower;
+        aTrack.TrackPower = fSignalPower * pow(WaveguidePowerCoupling(fStartFreq, fPitch),2.);
     }
 
     void FakeTrackSignalGenerator::InitiateEvent(Event* anEvent, int eventID)


### PR DESCRIPTION
very short change:

just makes it so that in the FTG, the "Track Powers" include the fact that the waveguide coupling is not necessarily 1 (before the histogram would just be a line at the user-configured power).