### PR TITLE
Feature/min pitch

### DIFF
--- a/Source/Core/LMCEvent.cc
+++ b/Source/Core/LMCEvent.cc
@@ -19,6 +19,21 @@ namespace locust
 {
     Event::Event() {}
     Event::~Event() {}
+
+    void Event::AddTrack(const Track aTrack)
+    {
+        StartFrequencies.push_back( aTrack.StartFrequency );
+        TrackPower.push_back( aTrack.TrackPower );
+        StartTimes.push_back( aTrack.StartTime );
+        TrackLengths.push_back( aTrack.TrackLength );
+        EndTimes.push_back( aTrack.EndTime );
+        Slopes.push_back( aTrack.Slope );
+        PitchAngles.push_back( aTrack.PitchAngle );
+
+        //update size
+        nTracks = StartFrequencies.size();
+    }
+
 }
 
 

--- a/Source/Core/LMCEvent.cc
+++ b/Source/Core/LMCEvent.cc
@@ -22,18 +22,15 @@ namespace locust
 
     void Event::AddTrack(const Track aTrack)
     {
-        StartFrequencies.push_back( aTrack.StartFrequency );
-        TrackPower.push_back( aTrack.TrackPower );
-        StartTimes.push_back( aTrack.StartTime );
-        TrackLengths.push_back( aTrack.TrackLength );
-        EndTimes.push_back( aTrack.EndTime );
-        Slopes.push_back( aTrack.Slope );
-        PitchAngles.push_back( aTrack.PitchAngle );
+        fStartFrequencies.push_back( aTrack.StartFrequency );
+        fTrackPowers.push_back( aTrack.TrackPower );
+        fStartTimes.push_back( aTrack.StartTime );
+        fTrackLengths.push_back( aTrack.TrackLength );
+        fEndTimes.push_back( aTrack.EndTime );
+        fSlopes.push_back( aTrack.Slope );
+        fPitchAngles.push_back( aTrack.PitchAngle );
 
         //update size
-        nTracks = StartFrequencies.size();
+        fNTracks = fStartFrequencies.size();
     }
-
 }
-
-

--- a/Source/Core/LMCEvent.hh
+++ b/Source/Core/LMCEvent.hh
@@ -26,10 +26,14 @@ namespace locust
         public:
             Event();
             virtual ~Event();
-            int EventID = -99;
-            int ntracks = -99;
-            double LOFrequency = -99.;
-            int RandomSeed = -99;
+
+            int EventID;
+            double LOFrequency;
+            int RandomSeed;
+
+            void AddTrack(const Track aTrack)
+
+        private:
             std::vector<double> StartFrequencies;
             std::vector<double> TrackPower;
             std::vector<double> StartTimes;
@@ -37,6 +41,8 @@ namespace locust
             std::vector<double> TrackLengths;
             std::vector<double> Slopes;
             std::vector<double> PitchAngles;
+
+            unsigned ntracks;
 
 
             ClassDef(Event,1)  // Root syntax.

--- a/Source/Core/LMCEvent.hh
+++ b/Source/Core/LMCEvent.hh
@@ -27,23 +27,21 @@ namespace locust
             Event();
             virtual ~Event();
 
-            int EventID;
-            double LOFrequency;
-            int RandomSeed;
+            void AddTrack(const Track aTrack);
 
-            void AddTrack(const Track aTrack)
+            int fEventID;
+            double fLOFrequency;
+            int fRandomSeed;
 
-        private:
-            std::vector<double> StartFrequencies;
-            std::vector<double> TrackPower;
-            std::vector<double> StartTimes;
-            std::vector<double> EndTimes;
-            std::vector<double> TrackLengths;
-            std::vector<double> Slopes;
-            std::vector<double> PitchAngles;
+            std::vector<double> fStartFrequencies;
+            std::vector<double> fTrackPowers;
+            std::vector<double> fStartTimes;
+            std::vector<double> fEndTimes;
+            std::vector<double> fTrackLengths;
+            std::vector<double> fSlopes;
+            std::vector<double> fPitchAngles;
 
-            unsigned ntracks;
-
+            unsigned fNTracks;
 
             ClassDef(Event,1)  // Root syntax.
 

--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -742,12 +742,13 @@ namespace locust
                     double voltage_phase = fStartVPhase;
                     unsigned tTrackIndexRange[2] = {static_cast<unsigned>(fStartTime / tLocustStep), static_cast<unsigned>(fEndTime / tLocustStep)};
                     tTrackIndexRange[1] = std::min(tTrackIndexRange[1], aSignal->TimeSize()*aSignal->DecimationFactor());
+                    double tInstantaneousFrequency = fStartFreq;
 
                     for( unsigned index = tTrackIndexRange[0]; index < tTrackIndexRange[1]; ++index ) // advance sampling time
                     {
-                        fStartFreq += fSlope * 1.e6/1.e-3 * tLocustStep;
-                        voltage_phase += 2.*LMCConst::Pi()*GetPitchCorrectedFrequency(fStartFreq) * tLocustStep;
-                        signalAmplitude = sqrt(50.) * sqrt(fSignalPower) * WaveguidePowerCoupling(fStartFreq, fPitch);
+                        tInstantaneousFrequency += fSlope * 1.e6/1.e-3 * tLocustStep;
+                        voltage_phase += 2.*LMCConst::Pi()*GetPitchCorrectedFrequency(tInstantaneousFrequency) * tLocustStep;
+                        signalAmplitude = sqrt(50.) * sqrt(fSignalPower) * WaveguidePowerCoupling(tInstantaneousFrequency, fPitch);
                         aSignal->LongSignalTimeComplex()[ch*aSignal->TimeSize()*aSignal->DecimationFactor() + index][0] += signalAmplitude * cos(voltage_phase-LO_phase);
                         aSignal->LongSignalTimeComplex()[ch*aSignal->TimeSize()*aSignal->DecimationFactor() + index][1] += signalAmplitude * cos(-LMCConst::Pi()/2. + voltage_phase-LO_phase);
                     }

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -86,6 +86,9 @@ namespace locust
             double GetStartPitchMin() const;
             void SetStartPitchMin( double aPitchMin );
 
+            double GetPitchMin() const;
+            void SetPitchMin( double aPitchMin );
+
             double GetTrackLengthMean() const;
             void SetTrackLengthMean( double aTrackLengthMean );
 
@@ -171,6 +174,7 @@ namespace locust
             double fStartTimeMin;
             double fStartPitchMin;
             double fStartPitchMax;
+            double fPitchMin;
             double fLO_frequency;
             double fTrackLengthMean;
             double fNTracksMean;

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -128,7 +128,7 @@ namespace locust
 
             Signal::State GetDomain() const;
             void SetDomain( Signal::State aDomain );
-            void SetTrackProperties(Track &aTrack, int TrackID, double TimeOffset);
+            void SetTrackProperties(Track &aTrack, int TrackID, double aTimeOffset);
             void InitiateEvent(Event* anEvent, int eventID);
             void PackEvent(Track& aTrack, Event* anEvent, int trackID) const;
             double rel_cyc(double energy, double b_field) const;
@@ -152,8 +152,8 @@ namespace locust
             double fTrackLength;
             double fStartTime;
             double fEndTime;
-            double fStartFreq;
-            double fJumpSize;
+            double fStartFrequency;
+            double fCurrentFrequency;
             int fNTracks;
 
         private:


### PR DESCRIPTION
Alterations to FTG. Goal: allow one to end events based on pitch angle (as well as specification).

Setting min-pitch enforces the minimum pitch angle, at which events are cut short. Event length is totally set by this in that case. 
Setting ntracks-mean to non-zero overrides this, number of tracks is totally set by geometric distribution.

I made some changes to DoGenerate(). There was an error where the multi channel sim would not work as fStartFreq was never reset. Now I have fStartFreq only changes on creation of new tracks, not due to radiation losses. 

In both cases, (ntracks = geometric, or from pitch angle), I get sensible tracks, but a good check is appreciated.
