### PR TITLE
Feature/buffermemory

### DIFF
--- a/Source/Generators/LMCDipoleSignalGenerator.hh
+++ b/Source/Generators/LMCDipoleSignalGenerator.hh
@@ -116,6 +116,7 @@ namespace locust
         double fLO_frequency;
         double fAmplitude;
         unsigned fFieldBufferSize;
+        int fSwapFrequency;
         
         std::vector<std::deque<double>> EFieldBuffer;
         std::vector<std::deque<double>> EPhaseBuffer;

--- a/Source/Generators/LMCPatchSignalGenerator.cc
+++ b/Source/Generators/LMCPatchSignalGenerator.cc
@@ -168,17 +168,12 @@ namespace locust
 
 
     // fields incident on patch.
-    void PatchSignalGenerator::RecordIncidentFields(FILE *fp, LMCThreeVector IncidentMagneticField, LMCThreeVector IncidentElectricField, LMCThreeVector IncidentKVector, double PatchPhi, double DopplerFrequency)
+    void PatchSignalGenerator::RecordIncidentFields(FILE *fp,  double t_old, int patchIndex, double zpatch, double tEFieldCoPol)
     {
-        double AOIFactor = GetAOIFactor(IncidentKVector, PatchPhi);  // k dot patchnormal
-        LMCThreeVector PatchPolarizationVector;
-        PatchPolarizationVector.SetComponents(-sin(PatchPhi), cos(PatchPhi), 0.0);
-        LMCThreeVector PatchCrossPolarizationVector;
-        PatchCrossPolarizationVector.SetComponents(0.0, 0.0, 1.0);  // axial direction.
-
-        double EFieldPatch = IncidentElectricField.Dot(PatchPolarizationVector);
-        double BFieldPatch = IncidentMagneticField.Dot(PatchCrossPolarizationVector);
-        fprintf(fp, "%10.4g %10.4g %10.4g %10.4g\n", EFieldPatch, BFieldPatch, DopplerFrequency/2./LMCConst::Pi(), t_old);
+    	if (t_old > 0.5e-9)
+         	{
+         	fprintf(fp, "%d %g %g\n", patchIndex, zpatch, tEFieldCoPol);
+         	}
     }
 
 
@@ -209,7 +204,6 @@ namespace locust
 
     		convolution=fTFReceiverHandler.ConvolveWithFIRFilter(PatchFIRBuffer[channel*fNPatchesPerStrip+patch]);
 
-    		PatchFIRBuffer[channel*fNPatchesPerStrip+patch].shrink_to_fit();  // memory deallocation.
     		return convolution;
     	}
     	else return 0.;
@@ -227,6 +221,19 @@ namespace locust
 
         return EFieldCoPol;
     }
+
+
+    double PatchSignalGenerator::GetEFieldCrossPol(PatchAntenna* currentPatch, LMCThreeVector IncidentElectricField, LMCThreeVector IncidentKVector, double PatchPhi, double DopplerFrequency)
+    {
+        double AOIFactor = GetAOIFactor(IncidentKVector, PatchPhi);  // k dot patchnormal
+        LMCThreeVector PatchCrossPolarizationVector;
+        PatchCrossPolarizationVector.SetComponents(0.0, 0.0, 1.0);  // axial direction.
+        double EFieldCrossPol = IncidentElectricField.Dot(PatchCrossPolarizationVector) * AOIFactor;
+
+        return EFieldCrossPol;
+    }
+
+
 
 
 
@@ -265,7 +272,8 @@ namespace locust
 
 
  		        double tEFieldCoPol = GetEFieldCoPol(currentPatch, tRadiatedElectricField, tRadiatedElectricField.Cross(tRadiatedMagneticField), PatchPhi, tDopplerFrequency);
-                if (fTextFileWriting==1) RecordIncidentFields(fp, tRadiatedMagneticField, tRadiatedElectricField, tRadiatedElectricField.Cross(tRadiatedMagneticField) , PatchPhi, tDopplerFrequency);
+ 		        double tEFieldCrossPol = GetEFieldCrossPol(currentPatch, tRadiatedElectricField, tRadiatedElectricField.Cross(tRadiatedMagneticField), PatchPhi, tDopplerFrequency);
+                if (fTextFileWriting==1) RecordIncidentFields(fp, t_old, patchIndex, currentPatch->GetPosition().GetZ(), tEFieldCoPol);
 
  	            FillBuffers(aSignal, tDopplerFrequency, tEFieldCoPol, fphiLO, index, channelIndex, patchIndex);
  	            double VoltageFIRSample = GetFIRSample(nfilterbins, dtfilter, channelIndex, patchIndex);
@@ -278,8 +286,8 @@ namespace locust
 
         } // channels loop
 
-
         t_old += 1./(fAcquisitionRate*1.e6*aSignal->DecimationFactor());
+        CleanupBuffers();
 
     }
 
@@ -314,14 +322,12 @@ namespace locust
 
     void PatchSignalGenerator::InitializeBuffers(unsigned filterbuffersize, unsigned fieldbuffersize)
     {
-
     	FieldBuffer aFieldBuffer;
     	EFieldBuffer = aFieldBuffer.InitializeBuffer(fNChannels, fNPatchesPerStrip, fieldbuffersize);
     	EFrequencyBuffer = aFieldBuffer.InitializeBuffer(fNChannels, fNPatchesPerStrip, fieldbuffersize);
     	LOPhaseBuffer = aFieldBuffer.InitializeBuffer(fNChannels, fNPatchesPerStrip, fieldbuffersize);
     	IndexBuffer = aFieldBuffer.InitializeUnsignedBuffer(fNChannels, fNPatchesPerStrip, fieldbuffersize);
     	PatchFIRBuffer = aFieldBuffer.InitializeBuffer(fNChannels, fNPatchesPerStrip, filterbuffersize);
-
     }
 
 
@@ -329,10 +335,10 @@ namespace locust
     {
     	FieldBuffer aFieldBuffer;
     	EFieldBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
-    	EFrequencyBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
-    	LOPhaseBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
+    	EFrequencyBuffer = aFieldBuffer.CleanupBuffer(EFrequencyBuffer);
+    	LOPhaseBuffer = aFieldBuffer.CleanupBuffer(LOPhaseBuffer);
+    	PatchFIRBuffer = aFieldBuffer.CleanupBuffer(PatchFIRBuffer);
     	IndexBuffer = aFieldBuffer.CleanupBuffer(IndexBuffer);
-
     }
 
 
@@ -342,7 +348,6 @@ namespace locust
     	fPowerCombiner.SetSMatrixParameters(fNPatchesPerStrip);
     	fPowerCombiner.SetVoltageDampingFactors(fNPatchesPerStrip);
     	return true;
-
     }
 
 
@@ -461,7 +466,6 @@ namespace locust
         printf("finished signal loop\n");
 
         fclose(fp);
-        CleanupBuffers();
         fRunInProgress = false;  // tell Kassiopeia to finish.
         fDoneWithSignalGeneration = true;  // tell LMCCyclotronRadExtractor
         WakeBeforeEvent();

--- a/Source/Generators/LMCPatchSignalGenerator.cc
+++ b/Source/Generators/LMCPatchSignalGenerator.cc
@@ -44,7 +44,8 @@ namespace locust
         LOPhaseBuffer( 1 ),
         IndexBuffer( 1 ),
         PatchFIRBuffer( 1 ),
-        fFieldBufferSize( 50 )
+        fFieldBufferSize( 50 ),
+		fSwapFrequency( 1000 )
 
     {
         fRequiredSignalState = Signal::kTime;
@@ -97,6 +98,10 @@ namespace locust
         if( aParam.has( "zshift-array" ) )
         {
             fZShiftArray = aParam["zshift-array"]().as_double();
+        }
+        if( aParam.has( "swap-frequency" ) )
+        {
+            fSwapFrequency = aParam["swap-frequency"]().as_int();
         }
         if( aParam.has( "xml-filename" ) )
         {
@@ -287,7 +292,7 @@ namespace locust
         } // channels loop
 
         t_old += 1./(fAcquisitionRate*1.e6*aSignal->DecimationFactor());
-        CleanupBuffers();
+        if ( index%fSwapFrequency == 0 ) CleanupBuffers();  // release memory
 
     }
 
@@ -310,10 +315,6 @@ namespace locust
     	EFrequencyBuffer[channel*fNPatchesPerStrip+patch].pop_front();
     	LOPhaseBuffer[channel*fNPatchesPerStrip+patch].pop_front();
     	IndexBuffer[channel*fNPatchesPerStrip+patch].pop_front();
-    	EFieldBuffer[channel*fNPatchesPerStrip+patch].shrink_to_fit();
-        EFrequencyBuffer[channel*fNPatchesPerStrip+patch].shrink_to_fit();
-        LOPhaseBuffer[channel*fNPatchesPerStrip+patch].shrink_to_fit();
-        IndexBuffer[channel*fNPatchesPerStrip+patch].shrink_to_fit();
 
     }
 

--- a/Source/Generators/LMCPatchSignalGenerator.hh
+++ b/Source/Generators/LMCPatchSignalGenerator.hh
@@ -38,7 +38,15 @@ namespace locust
      - "param-name": type -- Description
      - "lo-frequency" : double -- local oscillator frequency
      - "xml-filename" : std::string -- the name of the xml locust config file.
-     
+     - "buffer-size" :  std::int -- number of elements in deque buffers to contain field information.
+     	 	 These buffers control arrival times of fields and provide a short time series for the Hilbert transform.
+     - "lo-frequency":  local oscillator frequency in Hz.
+     - "array-radius":  radius of cylindrical antenna array in meters.
+     - "npatches-per-strip":  number of patch antennas on each strip.
+     - "patch-spacing":  spacing between patches on one strip in meters.
+     - "zshift-array":  shift of whole antenna array along z axis, for testing (meters).
+     - "swap-frequency":  number of digitizer samples after which buffer memory is reset.  This
+     	 	 becomes more important for large numbers of patches
 
     */
     class PatchSignalGenerator : public Generator
@@ -65,6 +73,7 @@ namespace locust
             std::string gxml_filename;
             bool fTextFileWriting;
             unsigned fFieldBufferSize;
+            int fSwapFrequency;
             double fphiLO; // voltage phase of LO in radians;
 
             bool WakeBeforeEvent();

--- a/Source/Generators/LMCPatchSignalGenerator.hh
+++ b/Source/Generators/LMCPatchSignalGenerator.hh
@@ -71,7 +71,8 @@ namespace locust
             bool ReceivedKassReady();
             double GetAOIFactor(LMCThreeVector IncidentKVector, double PatchPhi);
             double GetEFieldCoPol(PatchAntenna* currentPatch, LMCThreeVector IncidentElectricField, LMCThreeVector IncidentKVector, double PatchPhi, double DopplerFrequency);
-            void RecordIncidentFields(FILE *fp, LMCThreeVector IncidentMagneticField, LMCThreeVector IncidentElectricField, LMCThreeVector IncidentKVector, double PatchPhi, double DopplerFrequency);
+            double GetEFieldCrossPol(PatchAntenna* currentPatch, LMCThreeVector IncidentElectricField, LMCThreeVector IncidentKVector, double PatchPhi, double DopplerFrequency);
+            void RecordIncidentFields(FILE *fp, double t_old, int patchIndex, double zpatch, double tEFieldCoPol);
             double GetFIRSample(int nfilterbins, double dtfilter, unsigned channel, unsigned patch);
             void InitializeBuffers(unsigned filterbuffersize, unsigned fieldbuffersize);
             void CleanupBuffers();

--- a/Source/Generators/LMCPlaneWaveSignalGenerator.hh
+++ b/Source/Generators/LMCPlaneWaveSignalGenerator.hh
@@ -85,6 +85,7 @@ namespace locust
 	  	  double fAOI; // from json file, in degrees.
 	  	  double fAmplitude;
 	  	  double fFieldBufferSize;
+          int fSwapFrequency;
 	  	  double fphiLO; // voltage phase of LO in radians;
 
 	  	  double GetPatchFIRSample(double amp, double startphase, int patchIndex);
@@ -106,6 +107,8 @@ namespace locust
 	  	  void InitializeBuffers();
 	  	  void FillBuffers(unsigned bufferIndex, int digitizerIndex, double pwphase, double pwval);
 	  	  void PopBuffers(unsigned bufferIndex);
+          void CleanupBuffers();
+
     
 	  	  std::vector<std::deque<unsigned>> SampleIndexBuffer;
 	  	  std::vector<std::deque<double>> LOPhaseBuffer;

--- a/Source/Generators/LMCTurnstileSignalGenerator.cc
+++ b/Source/Generators/LMCTurnstileSignalGenerator.cc
@@ -37,7 +37,9 @@ namespace locust
     LOPhaseBuffer( 1 ),
     IndexBuffer( 1 ),
     PatchFIRBuffer( 1 ),
-    fFieldBufferSize( 50 )
+    fFieldBufferSize( 50 ),
+	fSwapFrequency( 1000 )
+
     
     {
         fRequiredSignalState = Signal::kTime;
@@ -60,6 +62,12 @@ namespace locust
             LERROR(lmclog,"Error configuring receiver FIRHandler class");
         }
 
+        if( aParam.has( "buffer-size" ) )
+        {
+            SetBufferSize( aParam.get_value< double >( "buffer-size", fFieldBufferSize ) );
+        	fHilbertTransform.SetBufferSize(aParam["buffer-size"]().as_int());
+        }
+
     	if(!fHilbertTransform.Configure(aParam))
     	{
     		LERROR(lmclog,"Error configuring receiver HilbertTransform class");
@@ -78,12 +86,6 @@ namespace locust
         if( aParam.has( "lo-frequency" ) )
         {
             SetLOFrequency( aParam.get_value< double >( "lo-frequency", fLO_frequency ) );
-        }
-        
-        if( aParam.has( "buffer-size" ) )
-        {
-            SetBufferSize( aParam.get_value< double >( "buffer-size", fFieldBufferSize ) );
-        	fHilbertTransform.SetBufferSize(aParam["buffer-size"]().as_int());
         }
         
         if( aParam.has( "input-signal-amplitude" ) )
@@ -369,8 +371,8 @@ namespace locust
                     PopBuffers(ch, patch);
                 }  // patch
             }  // channel
+            if ( index%fSwapFrequency == 0 ) CleanupBuffers();  // release memory
         }  // index
-        CleanupBuffers();
         return true;
     }
     
@@ -413,10 +415,10 @@ namespace locust
     {
         FieldBuffer aFieldBuffer;
         EFieldBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
-        EPhaseBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
-        EAmplitudeBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
-        EFrequencyBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
-        LOPhaseBuffer = aFieldBuffer.CleanupBuffer(EFieldBuffer);
+        EPhaseBuffer = aFieldBuffer.CleanupBuffer(EPhaseBuffer);
+        EAmplitudeBuffer = aFieldBuffer.CleanupBuffer(EAmplitudeBuffer);
+        EFrequencyBuffer = aFieldBuffer.CleanupBuffer(EFrequencyBuffer);
+        LOPhaseBuffer = aFieldBuffer.CleanupBuffer(LOPhaseBuffer);
         IndexBuffer = aFieldBuffer.CleanupBuffer(IndexBuffer);
         
     }

--- a/Source/Generators/LMCTurnstileSignalGenerator.hh
+++ b/Source/Generators/LMCTurnstileSignalGenerator.hh
@@ -115,6 +115,7 @@ namespace locust
         double fLO_frequency;
         double fAmplitude;
         unsigned fFieldBufferSize;
+        int fSwapFrequency;
         
         std::vector<std::deque<double>> EFieldBuffer;
         std::vector<std::deque<double>> EPhaseBuffer;

--- a/Source/Transmitters/LMCFieldBuffer.cc
+++ b/Source/Transmitters/LMCFieldBuffer.cc
@@ -60,27 +60,41 @@ namespace locust
   std::vector<std::deque<double>> FieldBuffer::CleanupBuffer(std::vector<std::deque<double>> buffer)
     {
 
-	for (unsigned i=0; i<buffer.size(); i++)
-	{
-		buffer[i].clear();
-		buffer[i].shrink_to_fit();
-	}
-    buffer.clear();
-    buffer.shrink_to_fit();
+    std::vector<std::deque<double>> empty;
+    empty.resize(buffer.size());
+
+    for (unsigned index = 0; index < buffer.size(); index ++ )
+    {
+    	for (std::deque<double>::iterator itdeque = buffer[index].begin(); itdeque != buffer[index].end(); ++itdeque)
+    	{
+    		empty[index].push_back(buffer[index].front());
+    		buffer[index].pop_front();
+    	}
+    }
+
+    std::swap( buffer, empty );
     return buffer;
     }
 
 
   std::vector<std::deque<unsigned>> FieldBuffer::CleanupBuffer(std::vector<std::deque<unsigned>> buffer)
     {
-    for (unsigned i=0; i<buffer.size(); i++)
-	  {
-	  buffer[i].clear();
-      buffer[i].shrink_to_fit();
-      }
-    buffer.clear();
-    buffer.shrink_to_fit();
+
+	std::vector<std::deque<unsigned>> empty;
+	empty.resize(buffer.size());
+
+	for (unsigned index = 0; index < buffer.size(); index ++ )
+	{
+	    for (std::deque<unsigned>::iterator itdeque = buffer[index].begin(); itdeque != buffer[index].end(); ++itdeque)
+	    {
+	    	empty[index].push_back(buffer[index].front());
+	    	buffer[index].pop_front();
+	    }
+	}
+
+	std::swap( buffer, empty );
     return buffer;
+
     }
 
 


### PR DESCRIPTION
These changes replace deque::shrink_to_fit with deque::swap for more direct memory management.  The changes are in LMCPatchSignalGenerator, LMCPlaneWaveSignalGenerator, LMCDipoleSignalGenerator, and LMCTurnstileSignalGenerator.  The swap interval is parametrized with a default value of 1000, tested for 30 channels with 80 patches each.   

This addresses https://github.com/project8/locust_mc/issues/87 .