### PR TITLE
Feature/fft hilberttransform

### DIFF
--- a/Source/Transforms/LMCComplexFFT.cc
+++ b/Source/Transforms/LMCComplexFFT.cc
@@ -197,6 +197,21 @@ namespace locust
         return true;
     }
     
+
+    bool ComplexFFT::RawReverseFFT(int size, fftw_complex* in, fftw_complex* out)
+    {
+        if(!IsInitialized) return false;
+
+        fInputArray = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * size);
+        fOutputArray = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * size);
+
+        fReversePlan = fftw_plan_dft_1d(size, fInputArray, fOutputArray, FFTW_BACKWARD, fTransform);
+        fftw_execute_dft(fReversePlan, in, out);
+
+        return true;
+    }
+
+
     bool ComplexFFT::SetupIFFT(int size, double intialBinValue, double freqResolution)
     {
         fSize=size;	

--- a/Source/Transforms/LMCComplexFFT.hh
+++ b/Source/Transforms/LMCComplexFFT.hh
@@ -49,6 +49,7 @@ namespace locust
         bool SetupIFFT(int,double, double);
         bool ForwardFFT(int, fftw_complex*, fftw_complex*);
         bool ReverseFFT(int, fftw_complex*, fftw_complex*);
+        bool RawReverseFFT(int, fftw_complex*, fftw_complex*);
 	double GetTimeResolution();
 	double GetFreqResolution();
         

--- a/Source/Transforms/LMCHilbertTransform.cc
+++ b/Source/Transforms/LMCHilbertTransform.cc
@@ -189,13 +189,7 @@ namespace locust
         SignalComplex = UnpackBuffer( FieldBuffer );
         originaldata = UnpackBuffer( FieldBuffer );
 
-/*        fftw_plan ForwardPlan;
-        ForwardPlan = fftw_plan_dft_1d(windowsize, SignalComplex, FFTComplex, FFTW_FORWARD, FFTW_ESTIMATE);
-        fftw_execute(ForwardPlan); // SignalComplex->FFTComplex
-*/  // old way.
-
         fComplexFFT.ForwardFFT(windowsize, SignalComplex, FFTComplex);
-
 
         // do the phase shifts
         for (int i = 0; i < windowsize; ++i)
@@ -212,17 +206,7 @@ namespace locust
             }
         }
 
-
-/*        fftw_plan ReversePlan;
-        ReversePlan = fftw_plan_dft_1d(windowsize, hilbert, SignalComplex, FFTW_BACKWARD, FFTW_ESTIMATE);
-        fftw_execute(ReversePlan); // hilbert->SignalComplex
-        */  // old way.
-
-
-        // this is giving a seg fault.  I think I am not defining the window function properly.
-        // I would like to have a rectangular window for now, to match the forward FFT.
-        fComplexFFT.ReverseFFT(windowsize, hilbert, SignalComplex);
-
+        fComplexFFT.RawReverseFFT(windowsize, hilbert, SignalComplex);
 
         for (int i = 0; i < windowsize; i++)  // normalize with 1/N
         {
@@ -251,6 +235,7 @@ namespace locust
 
 
         // dump to text file for debugging.
+        /*
     	FILE *fp = fopen("Hilbertresults.txt", "w");
     	for (int i=0; i<windowsize; i++)
     	{
@@ -259,9 +244,8 @@ namespace locust
     	fclose (fp);
     	printf(" *** debug file written to Hilbertresults.txt *** Press Ctrl-C to exit.\n");
     	getchar();  // Control-C to quit.
+         */
 
-
-//        fftw_destroy_plan(ReversePlan);
         delete[] hilbert;
         delete[] SignalComplex;
         delete[] FFTComplex;

--- a/Source/Transforms/LMCHilbertTransform.cc
+++ b/Source/Transforms/LMCHilbertTransform.cc
@@ -189,6 +189,11 @@ namespace locust
         SignalComplex = UnpackBuffer( FieldBuffer );
         originaldata = UnpackBuffer( FieldBuffer );
 
+/*        fftw_plan ForwardPlan;
+        ForwardPlan = fftw_plan_dft_1d(windowsize, SignalComplex, FFTComplex, FFTW_FORWARD, FFTW_ESTIMATE);
+        fftw_execute(ForwardPlan); // SignalComplex->FFTComplex
+*/  // old way.
+
         fComplexFFT.ForwardFFT(windowsize, SignalComplex, FFTComplex);
 
 
@@ -208,10 +213,15 @@ namespace locust
         }
 
 
-        fftw_plan ReversePlan;
+/*        fftw_plan ReversePlan;
         ReversePlan = fftw_plan_dft_1d(windowsize, hilbert, SignalComplex, FFTW_BACKWARD, FFTW_ESTIMATE);
         fftw_execute(ReversePlan); // hilbert->SignalComplex
-//        fComplexFFT.ReverseFFT(windowsize, hilbert, SignalComplex);
+        */  // old way.
+
+
+        // this is giving a seg fault.  I think I am not defining the window function properly.
+        // I would like to have a rectangular window for now, to match the forward FFT.
+        fComplexFFT.ReverseFFT(windowsize, hilbert, SignalComplex);
 
 
         for (int i = 0; i < windowsize; i++)  // normalize with 1/N
@@ -251,7 +261,7 @@ namespace locust
     	getchar();  // Control-C to quit.
 
 
-        fftw_destroy_plan(ReversePlan);
+//        fftw_destroy_plan(ReversePlan);
         delete[] hilbert;
         delete[] SignalComplex;
         delete[] FFTComplex;

--- a/Source/Transforms/LMCHilbertTransform.hh
+++ b/Source/Transforms/LMCHilbertTransform.hh
@@ -13,6 +13,7 @@
 #include <deque>
 #include "LMCConst.hh"
 #include "param.hh"
+#include "LMCComplexFFT.hh"
 
 
 namespace locust
@@ -20,10 +21,13 @@ namespace locust
  /*!
  @class HilbertTransform
  @author P. Slocum
- @brief Class to handle Hilbert transforms for deriving mag, phase, and mean of arbitrary incident real fields on arrival at receiver.
+ @brief Class to handle Hilbert transforms for deriving mag, phase, and mean of arbitrary
+ 	 incident real fields on arrival at receiver.
  @details
- Available configuration options:  none yet.
- No input parameters
+ Available configuration options:
+      - "hilbert-buffer-size" : int -- number of elements in deque buffer for FFT.
+      - "hilbert-buffer-margin" : int -- location (in number of elements away from edge of deque buffer)
+      	  at which to report mag phase and mean.
  */
     class HilbertTransform
     {
@@ -41,7 +45,7 @@ namespace locust
         private:
 
             fftw_complex* Transform(std::deque<double> FieldBuffer);
-            double* GetFrequencyData(std::deque<double> FrequencyBuffer);
+            fftw_complex* UnpackBuffer(std::deque<double> Buffer);
             double GetMean( std::deque<double> FieldBuffer );
             double GetMean( fftw_complex* array, int IQ, int size );
             double* GetSpan( fftw_complex* array, int IQ, int size );
@@ -49,6 +53,8 @@ namespace locust
             double QuadrantCorrection( double VI, double HilbertPhase, double HilbertMean );
             int fbufferMargin;
             int fbufferSize;
+            ComplexFFT fComplexFFT;
+
 
     };
 


### PR DESCRIPTION
A generic reverse FFT LMCComplexFFT::RawReverseFFT() is implemented that is compatible with the existing generic forward FFT.  Can it be unified with LMCComplexFFT::ReverseFFT() ?  LMCHilbertTransform is now working using the generic transforms in the LMCComplexFFT class. 