### PR TITLE
Feature/waveguideantenna

### DIFF
--- a/Config/Tutorial/LocustPhase3Template.json
+++ b/Config/Tutorial/LocustPhase3Template.json
@@ -6,6 +6,17 @@
        "decimate-signal", 
        "digitizer"
     ],
+
+
+    "lpf-fft":
+    {
+
+    },
+
+    "decimate-signal":
+    {
+
+    },
     
     "kass-signal":
     {
@@ -18,10 +29,15 @@
     {
         "lo-frequency": 25.8781e9,
         "array-radius": 0.05,
-        "npatches-per-strip": 21,
-        "patch-spacing": 0.0054,
-        "feed": "corporate",
-        "xml-filename": "/home/hep/baker/ps48/locust_mc/Config/Tutorial/Project8Phase3_WithRoot_Template.xml"
+        "npatches-per-strip": 2,
+        "zshift-array": 0.0,
+        "patch-spacing": 0.0068,
+        "power-combining-feed": "corporate",
+        "tf-receiver-filename": "/home/penny/locust_mc/Data/TransferFunctions/PatchTFLocust.txt",
+        "tf-receiver-bin-width": 0.01e9,
+        "buffer-size": 100,
+        "hilbert-buffer-margin": 50,
+        "xml-filename": "/home/penny/locust_mc/Config/Tutorial/Project8Phase3_WithRoot_Template.xml"
     },
 
     "freefield-signal":
@@ -32,10 +48,10 @@
 
     "simulation":
     {
-        "egg-filename": "/home/hep/baker/ps48/locust_mc/cbuild/bin/locust_mc.egg",
+        "egg-filename": "/home/penny/locust_mc/cbuild/bin/locust_mc.egg",
         "n-records": 1,
         "record-size": 81920,
-        "n-channels": 30
+        "n-channels": 1
     },
   
     "gaussian-noise":
@@ -46,8 +62,8 @@
 
     "digitizer":
     {
-    "v-range": 1.6e-5,
-    "v-offset": -0.8e-5
+    "v-range": 1.6e-7,
+    "v-offset": -0.8e-7
     }
 
 }

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -58,6 +58,7 @@ set( LOCUST_MC_HEADER_FILES
     RxComponents/LMCPowerCombiner.hh
     RxComponents/LMCReceiver.hh
     RxComponents/LMCPatchAntenna.hh
+    RxComponents/LMCSlotAntenna.hh
     RxComponents/LMCChannel.hh
     
 )
@@ -98,6 +99,7 @@ set( LOCUST_MC_SOURCE_FILES
     RxComponents/LMCPowerCombiner.cc
     RxComponents/LMCReceiver.cc
     RxComponents/LMCPatchAntenna.cc
+    RxComponents/LMCSlotAntenna.cc
     RxComponents/LMCChannel.cc
 
 )

--- a/Source/RxComponents/LMCPatchAntenna.cc
+++ b/Source/RxComponents/LMCPatchAntenna.cc
@@ -14,9 +14,6 @@ namespace locust
     PatchAntenna::PatchAntenna():
         antennaFactorSpline(antennaFactor.begin(), antennaFactor.end(), lowerBoundFrequency, frequencySpacingSpline ),
         gainSpline(gain.begin(), gain.end(), lowerBoundAngle, angularSpacingSpline),
-        copolarizationDirection(0,0,0),
-        normalDirection(0,0,0),
-        centerPosition(0,0,0),
         incidentElectricField(0,0,0),
         incidentMagneticField(0,0,0),
         instantaneousFrequency(0.),
@@ -26,15 +23,6 @@ namespace locust
 
     PatchAntenna::~PatchAntenna()
     {
-    }
-    LMCThreeVector PatchAntenna::GetPosition()
-    {
-        return centerPosition;
-    }
-
-    LMCThreeVector PatchAntenna::GetNormalDirection()
-    {
-    	return normalDirection;
     }
 
     void PatchAntenna::SetIncidentElectricField(const LMCThreeVector &incomingElectricField)
@@ -72,7 +60,7 @@ namespace locust
     {
         LMCThreeVector waveVector = incidentElectricField.Cross(incidentMagneticField);
         waveVector = waveVector.Unit(); //Normalize
-        double incidentAngle =  acos(waveVector.Dot(normalDirection));
+        double incidentAngle =  acos(waveVector.Dot(GetNormalDirection()));
         if(incidentAngle > LMCConst::Pi() / 2.)
             incidentAngle=LMCConst::Pi() - incidentAngle;
 
@@ -81,27 +69,9 @@ namespace locust
 
     double PatchAntenna::GetCopolarizationFactor()
     {
-      return incidentElectricField.Dot(copolarizationDirection);
+      return incidentElectricField.Dot(GetPolarizationDirection());
     }
 
-    void PatchAntenna::SetCenterPosition(const LMCThreeVector &newPosition)
-    {
-        centerPosition = newPosition;
-    }
-    void PatchAntenna::SetPolarizationDirection(const LMCThreeVector &copolDirection)
-    {
-        copolarizationDirection = copolDirection;
-    }
-
-    LMCThreeVector PatchAntenna::GetPolarizationDirection()
-     {
-         return copolarizationDirection;
-     }
-
-    void PatchAntenna::SetNormalDirection(const LMCThreeVector &normDirection)
-    {
-        normalDirection = normDirection;
-    }
 
 
 

--- a/Source/RxComponents/LMCPatchAntenna.hh
+++ b/Source/RxComponents/LMCPatchAntenna.hh
@@ -35,29 +35,14 @@ namespace locust
             virtual double GetVoltage();
             virtual double GetAnalogTimeDelay();
 
-
             void SetIncidentElectricField(const LMCThreeVector &incomingElectricField);
             void SetIncidentMagneticField(const LMCThreeVector &incomingMagneticField);
             void SetInstantaneousFrequency(const double &dopplerFrequency);
-
-            LMCThreeVector GetPosition();
-            LMCThreeVector GetNormalDirection();
-
-            void SetCenterPosition(const LMCThreeVector &newPosition);
-            void SetPolarizationDirection(const LMCThreeVector &copolDirection);
-            LMCThreeVector GetPolarizationDirection();
-            void SetNormalDirection(const LMCThreeVector &normDirection);
-
 
         private:
             double GetAntennaFactor();
             double GetGainFactor(); 
             double GetCopolarizationFactor();
-
-            LMCThreeVector copolarizationDirection;
-            LMCThreeVector normalDirection;
-
-            LMCThreeVector centerPosition;
 
             LMCThreeVector incidentElectricField;
             LMCThreeVector incidentMagneticField;

--- a/Source/RxComponents/LMCReceiver.cc
+++ b/Source/RxComponents/LMCReceiver.cc
@@ -9,8 +9,45 @@
 
 namespace locust
 {
-    Receiver::Receiver() {}
+    Receiver::Receiver():
+		copolarizationDirection(0,0,0),
+		normalDirection(0,0,0),
+		centerPosition(0,0,0)
+	{}
     Receiver::~Receiver() {}
+
+
+    LMCThreeVector Receiver::GetPolarizationDirection()
+    {
+    	return copolarizationDirection;
+    }
+
+    void Receiver::SetPolarizationDirection(const LMCThreeVector &copolDirection)
+    {
+        copolarizationDirection = copolDirection;
+    }
+
+
+    LMCThreeVector Receiver::GetNormalDirection()
+    {
+    	return normalDirection;
+    }
+
+    void Receiver::SetNormalDirection(const LMCThreeVector &normDirection)
+    {
+        normalDirection = normDirection;
+    }
+
+    LMCThreeVector Receiver::GetPosition()
+    {
+    	return centerPosition;
+    }
+
+    void Receiver::SetCenterPosition(const LMCThreeVector &newPosition)
+    {
+        centerPosition = newPosition;
+    }
+
 
 } /* namespace locust */
 

--- a/Source/RxComponents/LMCReceiver.hh
+++ b/Source/RxComponents/LMCReceiver.hh
@@ -25,10 +25,25 @@ namespace locust
 
         public:
             Receiver();
+            Receiver(double testvar);
             virtual ~Receiver();
 
             virtual double GetVoltage() = 0;
             virtual double GetAnalogTimeDelay() = 0;
+            LMCThreeVector GetPolarizationDirection();
+            void SetPolarizationDirection(const LMCThreeVector &copolDirection);
+            LMCThreeVector GetNormalDirection();
+            void SetNormalDirection(const LMCThreeVector &normDirection);
+            LMCThreeVector GetPosition();
+            void SetCenterPosition(const LMCThreeVector &newPosition);
+
+
+        private:
+            LMCThreeVector copolarizationDirection;
+            LMCThreeVector normalDirection;
+            LMCThreeVector centerPosition;
+
+
 };
 
 

--- a/Source/RxComponents/LMCSlotAntenna.cc
+++ b/Source/RxComponents/LMCSlotAntenna.cc
@@ -1,0 +1,24 @@
+/*
+ * LMCSlotAntenna.cc
+ *
+ *  Created on: Dec 19, 2019
+ *      Author: pslocum
+ */
+
+#include "LMCSlotAntenna.hh"
+
+
+namespace locust
+{
+
+    SlotAntenna::SlotAntenna()
+    {
+    }
+
+    SlotAntenna::~SlotAntenna()
+    {
+    }
+
+
+
+} /* namespace locust */

--- a/Source/RxComponents/LMCSlotAntenna.hh
+++ b/Source/RxComponents/LMCSlotAntenna.hh
@@ -1,0 +1,36 @@
+/*
+ * LMCSlotAntenna.hh
+ *
+ *  Created on: Dec 19, 2019
+ *      Author: pslocum
+ */
+
+#ifndef LMCSLOTANTENNA_HH_
+#define LMCSLOTANTENNA_HH_
+
+#include "LMCReceiver.hh"
+
+namespace locust
+{
+ /*!
+ @class SlotAntenna
+ @author P. Slocum
+ @brief Derived class describing the slot antenna
+ @details
+ Available configuration options:
+ No input parameters
+ */
+    class SlotAntenna: public Receiver
+    {
+
+        public:
+            SlotAntenna();
+            virtual ~SlotAntenna();
+
+
+    };
+
+
+} /* namespace locust */
+
+#endif /* LMCSLOTANTENNA_HH_ */


### PR DESCRIPTION
LMCReceiver base class is expanded to cover functionality common to patches and slot antennas.  A new derived class LMCSlotAntenna is created for waveguide slot array calculations.  This is where we are planning to define the single-slot pattern shape.  Comments/review are appreciated.