### PR TITLE
Hotfix/fix complex fft

### DIFF
--- a/Source/Core/LMCHFSSResponseFileHandler.cc
+++ b/Source/Core/LMCHFSSResponseFileHandler.cc
@@ -108,7 +108,6 @@ namespace locust
         fFIRComplex=(fftw_complex*)fftw_malloc(sizeof(fftw_complex) * fFIRNBins);
         fComplexFFT.ReverseFFT(fTFNBins,fTFComplex,fFIRComplex);
 	fResolution=fComplexFFT.GetTimeResolution();
-        std::cout <<"fFIRNBins  " <<fFIRNBins<<std::endl;
         for (int i = 0; i < fFIRNBins; ++i){
             fFilter.push_back(fFIRComplex[i][0]);
         }

--- a/Source/Core/LMCHFSSResponseFileHandler.cc
+++ b/Source/Core/LMCHFSSResponseFileHandler.cc
@@ -16,7 +16,8 @@ namespace locust
     LOGGER( lmclog, "HFSSResponseFileHandlerCore" );
     
     HFSSResponseFileHandlerCore::HFSSResponseFileHandlerCore():
-    fNBins(1000),
+    fTFNBins(1000),
+    fFIRNBins(2000),
     fResolution(1e-12),
     fNSkips(1),
     fComplexFFT(),
@@ -49,10 +50,10 @@ namespace locust
     double HFSSResponseFileHandlerCore::ConvolveWithFIRFilter(std::deque<double> inputBuffer)
     {
         double convolution=0.0;
-        if(fNBins<=0){
+        if(fFIRNBins<=0){
             LERROR(lmclog,"Number of bins in the filter should be positive");
         }
-        for(int i=0;i<fNBins;++i)
+        for(int i=0;i<fFIRNBins;++i)
         {
             convolution+=fFilter[i]*inputBuffer[i];
         }
@@ -89,25 +90,26 @@ namespace locust
   
     bool TFFileHandlerCore::ConvertTFtoFIR(std::vector<std::complex<double>> &tfArray)
     {
-        if(fNBins<=0)
+        if(fTFNBins<=0)
         {
             LERROR(lmclog,"The size of transfer function has to be positive integer");
             return false;
         }
         //Might need to be moved to a different function
-        fTFComplex=(fftw_complex*)fftw_malloc(sizeof(fftw_complex) * fNBins);
-        fFIRComplex=(fftw_complex*)fftw_malloc(sizeof(fftw_complex) * fNBins);
+        fTFComplex=(fftw_complex*)fftw_malloc(sizeof(fftw_complex) * fTFNBins);
         
-        for (int i = 0; i < fNBins; ++i)
+        for (int i = 0; i < fTFNBins; ++i)
         {
             fTFComplex[i][0]=tfArray.at(i).real();
             fTFComplex[i][1]=tfArray.at(i).imag();
         }
-        fComplexFFT.SetupIFFT(fNBins,fInitialTFIndex,fTFBinWidth);
-        fComplexFFT.ReverseFFT(fNBins,fTFComplex,fFIRComplex);
+        fComplexFFT.SetupIFFT(fTFNBins,fInitialTFIndex,fTFBinWidth);
+	fFIRNBins=fTFNBins+2*fComplexFFT.GetShiftNBins();
+        fFIRComplex=(fftw_complex*)fftw_malloc(sizeof(fftw_complex) * fFIRNBins);
+        fComplexFFT.ReverseFFT(fTFNBins,fTFComplex,fFIRComplex);
 	fResolution=fComplexFFT.GetTimeResolution();
-        
-        for (int i = 0; i < fNBins; ++i){
+        std::cout <<"fFIRNBins  " <<fFIRNBins<<std::endl;
+        for (int i = 0; i < fFIRNBins; ++i){
             fFilter.push_back(fFIRComplex[i][0]);
         }
         LDEBUG( lmclog, "Finished IFFT to convert transfer function to FIR");
@@ -120,7 +122,7 @@ namespace locust
 	{
 	    return true;	
 	}
-        fNBins=0;
+        fTFNBins=0;
         if(!ends_with(fHFSSFilename,".txt"))
         {
             LERROR(lmclog,"The TF file should end in .txt");
@@ -162,10 +164,10 @@ namespace locust
                         ++wordCount;
                     }
 		    // The TF values from HFSS are in GHz, so need to convert to Hz
-		    if(fNBins==0)fInitialTFIndex=tfIndex*pow(10.0,9);
+		    if(fTFNBins==0)fInitialTFIndex=tfIndex*pow(10.0,9);
                     const std::complex<double> temp(tfRealValue,tfImaginaryValue);
                     tfArray.push_back(temp);
-                    ++fNBins;
+                    ++fTFNBins;
                 }
             }
         }
@@ -197,7 +199,7 @@ namespace locust
 	{
 	    return true;	
 	}
-        fNBins=0;
+        fFIRNBins=0;
         if(!ends_with(fHFSSFilename,".txt"))
         {
             LERROR(lmclog,"The FIR file should end in .txt");
@@ -215,7 +217,7 @@ namespace locust
             if (count%fNSkips==0)
             {
                 fFilter.push_back(filterMagnitude);
-                ++fNBins;
+                ++fFIRNBins;
             }
             ++count;
         }

--- a/Source/Core/LMCHFSSResponseFileHandler.hh
+++ b/Source/Core/LMCHFSSResponseFileHandler.hh
@@ -35,7 +35,8 @@ namespace locust
         // Member variables
         std::string fHFSSFilename;
         std::vector<double> fFilter;
-        int fNBins;
+        int fTFNBins;
+        int fFIRNBins;
         double fResolution;
         int fNSkips;
         bool fHFSSFiletype;
@@ -48,7 +49,7 @@ namespace locust
     
     inline int HFSSResponseFileHandlerCore::GetFilterSize() const
     {
-        return fNBins;
+        return fFIRNBins;
     }
     
     inline double HFSSResponseFileHandlerCore::GetFilterResolution() const

--- a/Source/Transforms/LMCComplexFFT.cc
+++ b/Source/Transforms/LMCComplexFFT.cc
@@ -255,14 +255,14 @@ namespace locust
 	}
 	std::ofstream myfile;
 	myfile.open ("example.txt");
-        for (int i = 0; i < fSize; ++i)
+        for (int i = 0; i < 2*fSize+fNShiftBins; ++i)
 	{
-	   out[i][0]=fOutputArray[i][0]/std::sqrt(fSize)/2.0;
+	   out[i][0]=fOutputArray[i][0]*2/fTotalWindowSize;
         }
-        for (int i = 0; i < fTotalWindowSize; ++i){
+        for (int i = 0; i < fSize+2*fNShiftBins; ++i){
 	   myfile<<i;
 	   myfile<<",";
-	   myfile<<fOutputArray[i][0]/std::sqrt(fSize)/2.0;
+	   myfile<<fOutputArray[i][0]*2/fTotalWindowSize;
 	   myfile<<"\n";
 	}
 	myfile.close();
@@ -277,5 +277,10 @@ namespace locust
     double ComplexFFT::GetFreqResolution()
     {
         return fFreqResolution;
+    }
+
+    int ComplexFFT::GetShiftNBins()
+    {
+	return fNShiftBins;
     }
 } /* namespace locust */

--- a/Source/Transforms/LMCComplexFFT.hh
+++ b/Source/Transforms/LMCComplexFFT.hh
@@ -52,6 +52,7 @@ namespace locust
         bool RawReverseFFT(int, fftw_complex*, fftw_complex*);
 	double GetTimeResolution();
 	double GetFreqResolution();
+	int GetShiftNBins();
         
     private:
 	// Member variables


### PR DESCRIPTION
Fix the issues with IDFT process to convert from TF to FIR.
The issue was, FIR size was previously taken to be the same as the TF. This meant that if the FIR was either resonant or if the FIR is in general wide, some of FIR was cropped leading some lost energy. This also meant the size of the TF impacted the FIR and consequently the convolution with FIR. Now, the TF size and FIR size are decoupled and so the size of TF should not impact the convolution output. I also had to change the normalization to match the output for different TF ranges. Additionally, a fudge factor of 2 had to be added to make the Locust gains equal to HFSS gains. 
I checked to make sure that the TF size or the circular shift doesn't impact the results. Needs testing by the experts before merge. 