### PR TITLE
change angular change dist to exp like dist

### DIFF
--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -74,6 +74,9 @@ namespace locust
             double GetSignalPower() const;
             void SetSignalPower( double aPower );
 
+            double GetAlpha() const;
+            void SetAlpha( double aAlpha );
+
             double GetStartFrequencyMax() const;
             void SetStartFrequencyMax( double aFrequencyMax );
 
@@ -140,13 +143,14 @@ namespace locust
             double WaveguidePowerCoupling(double frequency, double pitchAngle);
             double GetEnergyLoss(double u, bool hydrogenScatter);
             double GetKa2(double eLoss, double T);
-            double GetThetaScatter(double eLoss, double T);
+            double GetThetaScatter(double u);
             double GetBField(double z);
             double GetPitchAngleZ(double theta_i, double B_i, double B_f);
             double GetPitchCorrectedFrequency(double frequency) const;
             double GetAxialFrequency();
             void ExtrapolateData(std::vector< std::pair<double, double> > &data, std::array<double, 3> fitPars);
 
+            double fAlpha;
             double fSlope;
             double fPitch;
             double fTrackLength;


### PR DESCRIPTION
Changes angular distribution of scatters in FTG to follow user parameterizable distribution, given that the previous results were found to be incorrect. 
Follows model: f(theta) ~ 1 / (1 + sin^2(theta) / alpha ^2)   
theta is scattering angle here: near zero.

Tests: generate MC sample from direct calls of GetThetaScatter(), compared to analytic form, for default of alpha = 0.01. (normalization on analytic form was hand tuned to roughly match). Can see that the MC CDF inversion does work. This would be used in FTG studies

![image](https://user-images.githubusercontent.com/5600717/75275772-06adf080-57d3-11ea-8563-961dee42df6d.png)
