### PR TITLE
Hotfix/reduce convolution speed

### DIFF
--- a/Source/Core/LMCHFSSResponseFileHandler.cc
+++ b/Source/Core/LMCHFSSResponseFileHandler.cc
@@ -55,10 +55,13 @@ namespace locust
         if(fFIRNBins<=0){
             LERROR(lmclog,"Number of bins in the filter should be positive");
         }
-        for(int i=0;i<fFIRNBins;++i)
-        {
-            convolution+=fFilter[i]*inputBuffer[i];
-        }
+	int firBinNumber=0;
+	for (auto it = inputBuffer.begin();it!=inputBuffer.end(); ++it)
+	{
+	    convolution+=*(it)*fFilter[firBinNumber];
+	    firBinNumber++;
+	}
+
         return convolution;
     }
     

--- a/Source/Transforms/LMCComplexFFT.cc
+++ b/Source/Transforms/LMCComplexFFT.cc
@@ -26,7 +26,7 @@ namespace locust
     fWindowFunction(NULL),
     fInputArray(NULL),
     fOutputArray(NULL),
-    fNShiftBins(5000),
+    fNShiftBins(2000),
     fForwardPlan(),
     fReversePlan()
     {


### PR DESCRIPTION
Not ready for merge yet but will work on this a bit more to try to smartly allocate the size of FIR filter. Currently, a modification of looping through the bins to increase the speed of convolution. Should increase the speed by a few % (nothing jaw dropping). 