### PR TITLE
Hotfix/planewave phasedelay

### DIFF
--- a/Source/Transmitters/LMCPlaneWaveTransmitter.cc
+++ b/Source/Transmitters/LMCPlaneWaveTransmitter.cc
@@ -50,11 +50,17 @@ namespace locust
     void PlaneWaveTransmitter::AddPropagationPhaseDelay(LMCThreeVector pointOfInterest)
     {
 	//Assuming the element strip is always along Z
-	double meanZ = GetMeanofFieldPoints(2);
+      
+	/*double meanZ = GetMeanofFieldPoints(2);
+	  double distanceFromCenter = meanZ - pointOfInterest.GetZ();*/
+      
 	/*int z_index = fieldPointIndex%nElementsPerStrip;
     	double stripLength = (nElementsPerStrip-1)*elementSpacing;
     	double distanceFromCenter = stripLength/2. - z_index*elementSpacing;*/
-    	double distanceFromCenter = meanZ - pointOfInterest.GetZ();
+
+      double endOfStrip = GetFieldPoint(0).GetZ();
+      double distanceFromCenter = pointOfInterest.GetZ() - endOfStrip;
+    
     	double phaseDelay = 2*LMCConst::Pi()*distanceFromCenter*sin(fAOI)*fRF_Frequency/LMCConst::C();
 	Transmitter::AddPropagationPhaseDelay(phaseDelay);
     }

--- a/Source/Transmitters/LMCPlaneWaveTransmitter.cc
+++ b/Source/Transmitters/LMCPlaneWaveTransmitter.cc
@@ -50,14 +50,16 @@ namespace locust
     void PlaneWaveTransmitter::AddPropagationPhaseDelay(LMCThreeVector pointOfInterest)
     {
 	//Assuming the element strip is always along Z
+
+      // Some previous attempts to get phase delay:
       
 	/*double meanZ = GetMeanofFieldPoints(2);
 	  double distanceFromCenter = meanZ - pointOfInterest.GetZ();*/
-      
 	/*int z_index = fieldPointIndex%nElementsPerStrip;
     	double stripLength = (nElementsPerStrip-1)*elementSpacing;
     	double distanceFromCenter = stripLength/2. - z_index*elementSpacing;*/
 
+      // Take the end of the array as the first place that the phase front of the planewave touches.
       double endOfStrip = GetFieldPoint(0).GetZ();
       double distanceFromCenter = pointOfInterest.GetZ() - endOfStrip;
     


### PR DESCRIPTION
A small fix to the AddPropagationDelay function. Before, it was adding a phase delay that corresponded to only half the element spacing for each additional element. Now, it calculates the correct phase delay, starting the planewave from one end of the strip. Patterns have been checked against previous work and HFSS and they look good.