### PR TITLE
allow explicit option: fixed initial energy for Kr Line Shape Dist

### DIFF
--- a/Source/Distributions/LMCKrComplexLineDistribution.cc
+++ b/Source/Distributions/LMCKrComplexLineDistribution.cc
@@ -369,9 +369,11 @@ namespace locust
 
         if(fEmittedPeak == "lorentzian")
             generated_energy += fLorentzian(*fRNEngine);
-        if(fEmittedPeak == "shake")
+        else if(fEmittedPeak == "shake")
             generated_energy += generate_shake();
-        
+        else if(fEmittedPeak == "dirac" || fEmittedPeak == "fixed") //just to be explicit
+            generated_energy += 0;
+
         //choose gas species
         std::string gas_species = generate_gas_species();
         


### PR DESCRIPTION
There was a feature request to have initial shape be constant, instead of just lorentzian/ or shake. Not a super necessary commit (as they could put in garbage in that field and it would have done the same thing), though good to be explicit