### PR TITLE
Updates to Slotted Waveguide to be compatible with new 5-slot TF

### DIFF
--- a/Source/RxComponents/LMCSlottedWaveguide.cc
+++ b/Source/RxComponents/LMCSlottedWaveguide.cc
@@ -15,7 +15,7 @@ namespace locust
 	LOGGER( lmclog, "SlottedWaveguide" );
 
     SlottedWaveguide::SlottedWaveguide():
-    		fImpedanceTransformation( 0.339 ) // sqrt(50./435.) unless already included in HFSS TF.
+    		fImpedanceTransformation( 0.358 ) // sqrt(50./390.), where 390 ohms is the 5-slot TF input array impedance
     {
     }
 
@@ -49,8 +49,6 @@ namespace locust
 		for (unsigned z_index=0; z_index<GetNElementsPerStrip(); z_index++)
 		{
 			double aFactor = fImpedanceTransformation;
-			//Adhoc scaling in case the slotted waveguide has fewer/more slots than 10
-			aFactor = aFactor/sqrt(GetNElementsPerStrip()/10.);
 			SetDampingFactor(z_index, aFactor);
 		}
 

--- a/Source/RxComponents/LMCSlottedWaveguide.cc
+++ b/Source/RxComponents/LMCSlottedWaveguide.cc
@@ -49,6 +49,8 @@ namespace locust
 		for (unsigned z_index=0; z_index<GetNElementsPerStrip(); z_index++)
 		{
 			double aFactor = fImpedanceTransformation;
+            //Adhoc scaling in case the slotted waveguide has fewer/more slots than 5
+            aFactor = aFactor/sqrt(GetNElementsPerStrip()/5.);
 			SetDampingFactor(z_index, aFactor);
 		}
 


### PR DESCRIPTION
Removed the scaling factor that was used for the 10-slot array. Changed the default impedance transformation for 390 ohms, the input impedance of the array for the 5-slot transfer function. (square root of 50 over 390). Note that if you want to use the 10-slot TF, you can only use it with 10 slots, and you would have to specify the impedance transformation in the config file.