### PR TITLE
Feature/exampleoutputpaths

### DIFF
--- a/Config/JustKass.xml.in
+++ b/Config/JustKass.xml.in
@@ -54,7 +54,7 @@
 <external_define name="count" value="1"/>
 <external_define name="seed" value="112377"/>
 
-<external_define name="output_path" value="./"/> 
+<external_define name="output_path" value="${CMAKE_INSTALL_PREFIX}/output"/> 
 <external_define name="file" value="Phase1Seed[seed]Output"/>
 
 <define name="config_path" value="${CMAKE_INSTALL_PREFIX}/config"/>

--- a/Config/JustKassFieldMap.xml.in
+++ b/Config/JustKassFieldMap.xml.in
@@ -24,7 +24,7 @@
 <external_define name="count" value="1"/>
 <external_define name="seed" value="335"/>
 
-<external_define name="output_path" value="./"/> 
+<external_define name="output_path" value="${CMAKE_INSTALL_PREFIX}/output"/> 
 <external_define name="file" value="FieldLineSeed[seed]Output"/>
 
 <define name="config_path" value="${CMAKE_INSTALL_PREFIX}/config"/>

--- a/Config/LocustFakeTrack.json.in
+++ b/Config/LocustFakeTrack.json.in
@@ -44,7 +44,7 @@
     "n-events": 1,
     "hydrogen-fraction":1,
     "pitch-correction":0,
-    "root-filename": "LocustEvent.root"
+    "root-filename": "${CMAKE_INSTALL_PREFIX}/output/LocustEvent.root"
     },
     
     "simulation":

--- a/Config/LocustFakeTrack.json.in
+++ b/Config/LocustFakeTrack.json.in
@@ -49,7 +49,7 @@
     
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "n-records": 1,
         "n-channels": 1,
         "record-size": 4194304

--- a/Config/LocustFreeSpaceTemplate.json.in
+++ b/Config/LocustFreeSpaceTemplate.json.in
@@ -38,7 +38,7 @@
 
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/bin/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "n-records": 1,
         "record-size": 300000,
         "n-channels": 1

--- a/Config/LocustKass_FreeSpace_Template.xml.in
+++ b/Config/LocustKass_FreeSpace_Template.xml.in
@@ -56,7 +56,7 @@
 <external_define name="count" value="1"/>
 <external_define name="seed" value="112377"/>
 
-<external_define name="output_path" value="./"/> 
+<external_define name="output_path" value="${CMAKE_INSTALL_PREFIX}/output"/> 
 <external_define name="file" value="Phase3Seed[seed]Output"/>
 
 <define name="config_path" value="${CMAKE_INSTALL_PREFIX}/config"/>

--- a/Config/LocustKass_Waveguide_Template.xml.in
+++ b/Config/LocustKass_Waveguide_Template.xml.in
@@ -55,7 +55,7 @@
 <external_define name="count" value="1"/>
 <external_define name="seed" value="112377"/>
 
-<external_define name="output_path" value="./"/> 
+<external_define name="output_path" value="${CMAKE_INSTALL_PREFIX}/output"/> 
 <external_define name="file" value="Phase1Seed[seed]Output"/>
 
 <define name="config_path" value="${CMAKE_INSTALL_PREFIX}/config"/>

--- a/Config/LocustMagDipoleAntennaTemplate.json.in
+++ b/Config/LocustMagDipoleAntennaTemplate.json.in
@@ -37,7 +37,7 @@
 
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/bin/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "n-records": 1,
         "record-size": 8192,
         "n-channels": 1

--- a/Config/LocustPlaneWaveTemplate.json.in
+++ b/Config/LocustPlaneWaveTemplate.json.in
@@ -37,7 +37,7 @@
 
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/bin/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "n-records": 1,
         "record-size": 8192,
         "n-channels": 1

--- a/Config/LocustTestSignal.json.in
+++ b/Config/LocustTestSignal.json.in
@@ -25,7 +25,7 @@
     
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/bin/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc/locust_mc.egg",
         "n-records": 1,
         "n-channels": 1,
         "record-size": 8192

--- a/Config/LocustWaveguideTemplate.json.in
+++ b/Config/LocustWaveguideTemplate.json.in
@@ -30,7 +30,7 @@
 
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/bin/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "n-records": 1,
         "record-size": 819200
     },


### PR DESCRIPTION
The default output path in compiled examples is now cbuild/output/ .  This allows easier binding of the output directory to local directories in singularity.