### PR TITLE
Edited last example output path (LMCTestSignalGenerator) so that the …

### DIFF
--- a/Config/LocustTestSignal.json.in
+++ b/Config/LocustTestSignal.json.in
@@ -25,7 +25,7 @@
     
     "simulation":
     {
-        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc/locust_mc.egg",
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "n-records": 1,
         "n-channels": 1,
         "record-size": 8192


### PR DESCRIPTION
…example runs in or out of the container, without editing or recompiling.