### PR TITLE
Hotfix/array2vector

### DIFF
--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -393,11 +393,10 @@ namespace locust
     	if (fabs(EFieldBuffer[channel*fNElementsPerStrip+element].front()) > 0.)  // field arrived yet?
     	{
 
-    		double* HilbertMagPhaseMean = new double[3];
+    		std::vector<double> HilbertMagPhaseMean; HilbertMagPhaseMean.resize(3);
     		HilbertMagPhaseMean = fHilbertTransform.GetMagPhaseMean(EFieldBuffer[channel*fNElementsPerStrip+element], EFrequencyBuffer[channel*fNElementsPerStrip+element]);
     		HilbertMag = HilbertMagPhaseMean[0];
     		HilbertPhase = HilbertMagPhaseMean[1];
-    		delete[] HilbertMagPhaseMean;
 
     		for (int i=0; i < nfilterbins; i++)  // populate filter with field.
     		{
@@ -438,7 +437,7 @@ namespace locust
             	Receiver* currentElement = allRxChannels[channelIndex][elementIndex];
                 sampleIndex = channelIndex*signalSize*aSignal->DecimationFactor() + index;  // which channel and which sample
 
-                double* tFieldSolution = new double[2];
+                std::vector<double> tFieldSolution; //tFieldSolution.resize(2);
                 if (!fTransmitter->IsKassiopeia())
                 {
                 	tFieldSolution = fTransmitter->GetEFieldCoPol(tTotalElementIndex, 1./(fAcquisitionRate*1.e6*aSignal->DecimationFactor()));

--- a/Source/Transforms/LMCHilbertTransform.cc
+++ b/Source/Transforms/LMCHilbertTransform.cc
@@ -69,9 +69,7 @@ namespace locust
     std::vector<double> HilbertTransform::GetMagPhaseMean(std::deque<double> FieldBuffer, std::deque<double> FrequencyBuffer)
     {
 
-    	fftw_complex* transformeddata;
-//        transformeddata = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * FieldBuffer.size());
-        transformeddata = Transform( FieldBuffer );
+    	fftw_complex* transformeddata = Transform( FieldBuffer );
     	unsigned hilbertindex = fbufferMargin;
     	std::vector<double> magphasemean; magphasemean.resize(3);
 

--- a/Source/Transforms/LMCHilbertTransform.cc
+++ b/Source/Transforms/LMCHilbertTransform.cc
@@ -66,12 +66,14 @@ namespace locust
     }
 
 
-    double* HilbertTransform::GetMagPhaseMean(std::deque<double> FieldBuffer, std::deque<double> FrequencyBuffer)
+    std::vector<double> HilbertTransform::GetMagPhaseMean(std::deque<double> FieldBuffer, std::deque<double> FrequencyBuffer)
     {
 
-    	fftw_complex* transformeddata = Transform( FieldBuffer );
+    	fftw_complex* transformeddata;
+//        transformeddata = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * FieldBuffer.size());
+        transformeddata = Transform( FieldBuffer );
     	unsigned hilbertindex = fbufferMargin;
-    	double* magphasemean = new double[3];
+    	std::vector<double> magphasemean; magphasemean.resize(3);
 
     	double mag = pow(transformeddata[hilbertindex][0]*transformeddata[hilbertindex][0] + transformeddata[hilbertindex][1]*transformeddata[hilbertindex][1], 0.5);
     	double mean = 0.;  // this is set to zero in HilbertTransform::Transform().
@@ -133,9 +135,9 @@ namespace locust
     }
 
 
-    double* HilbertTransform::GetSpan( fftw_complex* array, int IQ, int size )
+    std::vector<double> HilbertTransform::GetSpan( fftw_complex* array, int IQ, int size )
     {
-    	double* span = new double[2];
+    	std::vector<double> span; span.resize(2);
     	double max = -99.;
     	double min = 99.;
     	for (unsigned i=size/4; i<3*size/4; i++)
@@ -230,8 +232,8 @@ namespace locust
         }
 
 
-        double* spanI = GetSpan(originaldata, 0, FieldBuffer.size());
-        double* spanQ = GetSpan(originaldata, 1, FieldBuffer.size());
+        std::vector<double> spanI = GetSpan(originaldata, 0, FieldBuffer.size());
+        std::vector<double> spanQ = GetSpan(originaldata, 1, FieldBuffer.size());
 
         for (int i = 0; i < windowsize; ++i)
         {

--- a/Source/Transforms/LMCHilbertTransform.hh
+++ b/Source/Transforms/LMCHilbertTransform.hh
@@ -33,7 +33,7 @@ namespace locust
             HilbertTransform();
             virtual ~HilbertTransform();
             bool Configure( const scarab::param_node& aNode);
-            double* GetMagPhaseMean(std::deque<double> FieldBuffer, std::deque<double> FrequencyBuffer);
+            std::vector<double> GetMagPhaseMean(std::deque<double> FieldBuffer, std::deque<double> FrequencyBuffer);
             void SetBufferSize( int aBufferSize );
             void SetBufferMargin( int aBufferMargin );
             int GetBufferSize();
@@ -46,7 +46,7 @@ namespace locust
             double* GetFrequencyData(std::deque<double> FrequencyBuffer);
             double GetMean( std::deque<double> FieldBuffer );
             double GetMean( fftw_complex* array, int IQ, int size );
-            double* GetSpan( fftw_complex* array, int IQ, int size );
+            std::vector<double> GetSpan( fftw_complex* array, int IQ, int size );
             double GetPhase( double VI, double VQ, double VMean);
             double QuadrantCorrection( double VI, double HilbertPhase, double HilbertMean );
             int fbufferMargin;

--- a/Source/Transmitters/LMCAntennaSignalTransmitter.cc
+++ b/Source/Transmitters/LMCAntennaSignalTransmitter.cc
@@ -85,7 +85,7 @@ namespace locust
      }
 
 
-    double* AntennaSignalTransmitter::GetEFieldCoPol(int fieldPointIndex, double dt)
+    std::vector<double> AntennaSignalTransmitter::GetEFieldCoPol(int fieldPointIndex, double dt)
     {
     	LMCThreeVector pointOfInterest=GetFieldPoint(fieldPointIndex);
         double estimatedField=0.0;
@@ -126,7 +126,7 @@ namespace locust
 
         } // nAntennas
 
-        double* FieldSolution = new double[2];
+        std::vector<double> FieldSolution; FieldSolution.resize(2);
         FieldSolution[0] = estimatedField / fTransmitterHardware->GetPropagationDistance(pointOfInterest); // field at point
         FieldSolution[1] = 2. * LMCConst::Pi() * fInputFrequency; // rad/s
 

--- a/Source/Transmitters/LMCAntennaSignalTransmitter.hh
+++ b/Source/Transmitters/LMCAntennaSignalTransmitter.hh
@@ -50,7 +50,7 @@ namespace locust
         bool Configure( const scarab::param_node& aNode );
         
         /// Generate the electric field based on the voltage input from the config file and convolution with FIR
-        virtual double* GetEFieldCoPol(int fieldPointIndex, double dt);
+        virtual std::vector<double> GetEFieldCoPol(int fieldPointIndex, double dt);
         
         /// Get initial phase delay
         double GetInitialPhaseDelay();

--- a/Source/Transmitters/LMCKassTransmitter.cc
+++ b/Source/Transmitters/LMCKassTransmitter.cc
@@ -45,7 +45,7 @@ namespace locust
     	fFieldSolver.AddFieldPoint(fieldPoint);
     }
 
-    double* KassTransmitter::SolveKassFields(LMCThreeVector pointOfInterest, LMCThreeVector coPolDirection, double tReceiverTime, unsigned tTotalElementIndex)
+    std::vector<double> KassTransmitter::SolveKassFields(LMCThreeVector pointOfInterest, LMCThreeVector coPolDirection, double tReceiverTime, unsigned tTotalElementIndex)
     {
 
         fFieldSolver.SetFieldEvent(tReceiverTime, tTotalElementIndex);
@@ -63,7 +63,8 @@ namespace locust
 	    double tEFieldCoPol = tRadiatedElectricField.Dot(coPolDirection);
 	    SetIncidentKVector(tTotalElementIndex,tRadiatedElectricField.Cross(tRadiatedMagneticField));
 
-        double* tSolution = new double[2];
+        std::vector<double> tSolution;
+        tSolution.resize(2);
         tSolution[0] = tEFieldCoPol;
         tSolution[1] = tDopplerFrequency;
 

--- a/Source/Transmitters/LMCKassTransmitter.hh
+++ b/Source/Transmitters/LMCKassTransmitter.hh
@@ -15,7 +15,6 @@
 #include "LMCLienardWiechert.hh"
 #include "LMCGlobalsDeclaration.hh"
 
-
 namespace locust
 {
 
@@ -44,8 +43,8 @@ namespace locust
 
         virtual bool IsKassiopeia();
 
-    	double* SolveKassFields(LMCThreeVector pointOfInterest, LMCThreeVector coPolDirection, double tReceiverTime, unsigned tTotalElementIndex);
-        void InitializeFieldPoint(LMCThreeVector fieldPoint);
+    	std::vector<double> SolveKassFields(LMCThreeVector pointOfInterest, LMCThreeVector coPolDirection, double tReceiverTime, unsigned tTotalElementIndex);
+    	void InitializeFieldPoint(LMCThreeVector fieldPoint);
 
     private:
 

--- a/Source/Transmitters/LMCPlaneWaveTransmitter.cc
+++ b/Source/Transmitters/LMCPlaneWaveTransmitter.cc
@@ -74,7 +74,7 @@ namespace locust
     	//fIncidentKVector.SetComponents(cos(fAOI), 0.0, sin(fAOI));
     }
 
-    double* PlaneWaveTransmitter::GetEFieldCoPol(int fieldPointIndex, double dt)
+    std::vector<double> PlaneWaveTransmitter::GetEFieldCoPol(int fieldPointIndex, double dt)
     {
     	double initialPhaseDelay = GetPropagationPhaseDelay(fieldPointIndex); 
 		double fieldAmp = fAmplitude;
@@ -84,7 +84,7 @@ namespace locust
 		double fieldValue = fieldAmp*cos(fPhaseDelay + initialPhaseDelay);
 		//AddIncidentKVector(pointOfInterest);
 
-        double* fieldSolution = new double[2];
+        std::vector<double> fieldSolution; fieldSolution.resize(2);
         fieldSolution[0] = fieldValue;
         fieldSolution[1] = 2. * LMCConst::Pi() * fRF_Frequency;  // rad/s
 

--- a/Source/Transmitters/LMCPlaneWaveTransmitter.hh
+++ b/Source/Transmitters/LMCPlaneWaveTransmitter.hh
@@ -39,7 +39,7 @@ namespace locust
 
         bool Configure( const scarab::param_node& aNode );
 
-        virtual double* GetEFieldCoPol(int fieldIndexPoint, double dt);
+        virtual std::vector<double> GetEFieldCoPol(int fieldIndexPoint, double dt);
 
 
     private:

--- a/Source/Transmitters/LMCTransmitter.hh
+++ b/Source/Transmitters/LMCTransmitter.hh
@@ -36,9 +36,9 @@ namespace locust
             virtual void TxSayHello();
 
             virtual bool Configure( const scarab::param_node& ){};
-            virtual double* GetEFieldCoPol(int fieldPointIndex, double dt) {};
+            virtual std::vector<double> GetEFieldCoPol(int fieldPointIndex, double dt) {};
 
-            virtual double* SolveKassFields(LMCThreeVector pointOfInterest, LMCThreeVector coPolDirection, double tReceiverTime, unsigned tTotalElementIndex) {};
+            virtual std::vector<double> SolveKassFields(LMCThreeVector pointOfInterest, LMCThreeVector coPolDirection, double tReceiverTime, unsigned tTotalElementIndex) {};
             virtual void InitializeFieldPoint(LMCThreeVector fieldPoint);
 
             virtual bool IsKassiopeia() {return false;};


### PR DESCRIPTION
Converted array functions to vector functions for easier memory deallocation.  This effect has been more noticeable in long simulations with high channel counts.  Will still need to test some examples, but these are the relevant changes that are being suggested.