### PR TITLE
Feature/ftg fscd

### DIFF
--- a/Config/LocustFreeSpaceFakeTrack.json.in
+++ b/Config/LocustFreeSpaceFakeTrack.json.in
@@ -1,0 +1,73 @@
+{
+    "generators":
+    [          
+       "free-space-fake",
+       "lpf-fft",
+       "decimate-signal",
+       "gaussian-noise",
+       "digitizer"
+    ],
+
+    "free-space-fake":
+    {
+    "start-frequency":
+        {
+            "name": "dirac",
+            "value": 26.025e9
+        },
+    "slope":
+        {
+            "name":"dirac",
+            "value": 0.0
+        },
+    "track-length":
+        {
+            "name":"dirac",
+            "value": 4.0e-6
+        },
+    "radius":
+        {
+            "name":"dirac",
+            "value": 0.02
+        },
+    "grad-B-frequency": 2.410e3,
+    "signal-power": 1.0e-15,
+    "start-vphase": 0.0,
+    "start-time-min": 0,
+    "start-time-max": 1e-7,
+    "lo-frequency": 26.0e9,
+    "ntracks-mean": 1.0,
+    "random-seed": 17,
+    "n-events": 1,
+    "root-filename": "${CMAKE_INSTALL_PREFIX}/output/LocustEvent.root"
+    },
+    
+    "simulation":
+    {
+        "egg-filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
+        "n-records": 1,
+        "n-channels": 30,
+        "record-size": 131072
+    },
+
+    "gaussian-noise":
+    {
+    "noise-temperature": 1,
+    "domain": "time"
+    },
+
+    "digitizer":
+    {
+    "v-range": 4.0e-7,
+    "v-offset": -2.0e-7
+    },
+    
+    "decimate-signal":
+    {
+    },
+
+    "lpf-fft":
+    {
+    }
+
+}

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -190,6 +190,7 @@ if (locust_mc_BUILD_WITH_ROOT)
         Core/LMCTrack.hh
         Core/LMCRunParameters.hh
         Generators/LMCFakeTrackSignalGenerator.hh    
+        Generators/LMCFakeFreeSpaceSignalGenerator.hh
 	    IO/LMCFileWriter.hh
     	IO/LMCRootTreeWriter.hh
     	IO/LMCRootHistoWriter.hh
@@ -201,6 +202,7 @@ if (locust_mc_BUILD_WITH_ROOT)
         Core/LMCTrack.cc
         Core/LMCRunParameters.cc
         Generators/LMCFakeTrackSignalGenerator.cc   
+        Generators/LMCFakeFreeSpaceSignalGenerator.cc
 	    IO/LMCFileWriter.cc
     	IO/LMCRootTreeWriter.cc
     	IO/LMCRootHistoWriter.cc

--- a/Source/Core/LMCEvent.cc
+++ b/Source/Core/LMCEvent.cc
@@ -29,6 +29,8 @@ namespace locust
         fEndTimes.push_back( aTrack.EndTime );
         fSlopes.push_back( aTrack.Slope );
         fPitchAngles.push_back( aTrack.PitchAngle );
+        fRadii.push_back( aTrack.Radius );
+        fRadialPhases.push_back( aTrack.RadialPhase );
 
         //update size
         fNTracks = fStartFrequencies.size();

--- a/Source/Core/LMCEvent.hh
+++ b/Source/Core/LMCEvent.hh
@@ -40,6 +40,8 @@ namespace locust
             std::vector<double> fTrackLengths;
             std::vector<double> fSlopes;
             std::vector<double> fPitchAngles;
+            std::vector<double> fRadii;
+            std::vector<double> fRadialPhases;
 
             unsigned fNTracks;
 

--- a/Source/Core/LMCRunLengthCalculator.cc
+++ b/Source/Core/LMCRunLengthCalculator.cc
@@ -128,6 +128,11 @@ namespace locust
          return;
      }
 
+    void RunLengthCalculator::Visit( const FakeFreeSpaceSignalGenerator* )
+    {
+        // nothing to see here, move along, please
+        return;
+    }
 
     void RunLengthCalculator::Visit( const FakeTrackSignalGenerator* )
     {

--- a/Source/Core/LMCRunLengthCalculator.hh
+++ b/Source/Core/LMCRunLengthCalculator.hh
@@ -95,6 +95,7 @@ namespace locust
             void Visit( const FreeFieldSignalGenerator* );
             void Visit( const ArraySignalGenerator* );
             void Visit( const GaussianNoiseGenerator* );
+            void Visit( const FakeFreeSpaceSignalGenerator* );
             void Visit( const FakeTrackSignalGenerator* );
             void Visit( const TestSignalGenerator* );
             void Visit( const LowPassFilterFFTGenerator* );

--- a/Source/Core/LMCTrack.hh
+++ b/Source/Core/LMCTrack.hh
@@ -38,6 +38,7 @@ namespace locust
             double Slope = -99.;
             double PitchAngle = -99.;
             double Radius = -99.;
+            double RadialPhase = -99.;
 
             ClassDef(Track,1)  // Root syntax.
 

--- a/Source/Core/LMCVisitor.hh
+++ b/Source/Core/LMCVisitor.hh
@@ -12,6 +12,7 @@ namespace locust
 {
     class Generator;
     class GaussianNoiseGenerator;
+    class FakeFreeSpaceSignalGenerator;
     class FakeTrackSignalGenerator;
     class TestSignalGenerator;
     class TestFIRFilterGenerator;
@@ -36,6 +37,7 @@ namespace locust
             virtual void Visit( const FreeFieldSignalGenerator* ) = 0;
             virtual void Visit( const ArraySignalGenerator* ) = 0;
             virtual void Visit( const GaussianNoiseGenerator* ) = 0;
+            virtual void Visit( const FakeFreeSpaceSignalGenerator* ) = 0;
             virtual void Visit( const FakeTrackSignalGenerator* ) = 0;
             virtual void Visit( const TestSignalGenerator* ) = 0;
             virtual void Visit( const LowPassFilterFFTGenerator* ) = 0;

--- a/Source/Generators/LMCFakeFreeSpaceSignalGenerator.cc
+++ b/Source/Generators/LMCFakeFreeSpaceSignalGenerator.cc
@@ -1,0 +1,603 @@
+/*
+ * LMCFakeFreeSpaceSignalGenerator.cc
+ *
+ *  Created on: Nov. 26, 2020
+ *      Author: buzinsky
+ */
+
+#include "LMCFakeFreeSpaceSignalGenerator.hh"
+#include "LMCDigitizer.hh"
+#include "logger.hh"
+#include "LMCConst.hh"
+#include "LMCThreeVector.hh"
+#include "path.hh"
+#include <sstream>
+#include <random>
+#include <math.h>
+#include <string>
+#include <iostream>
+
+using std::string;
+
+namespace locust
+{
+    LOGGER( lmclog, "FakeFreeSpaceSignalGenerator" );
+
+    MT_REGISTER_GENERATOR(FakeFreeSpaceSignalGenerator, "free-space-fake");
+
+    FakeFreeSpaceSignalGenerator::FakeFreeSpaceSignalGenerator( const std::string& aName ) :
+            Generator( aName ),
+            fDoGenerateFunc( &FakeFreeSpaceSignalGenerator::DoGenerateTime ),
+            fSignalPower( 0. ),
+            fStartVPhase( 0. ),
+            fStartTimeMin( 0. ),
+            fStartTimeMax( 0. ),
+            fLO_frequency( 0. ),
+            fNTracksMean( 0. ),
+            fBField( 1.0 ),
+            fRandomSeed( 0 ),
+            fNEvents( 1 ),
+            fAntennaRadius( 0.05 ),
+            fRadius( 0. ),
+            fGradBFrequency( 0. ),
+            fRadialPhase( 0. ),
+            fRandomEngine( 0 ),
+            fRootFilename( "LocustEvent.root" ),
+            fSlope( 0. ),
+            fTrackLength( 0. ),
+            fStartTime( 0. ),
+            fEndTime( 0. ),
+            fStartFrequency( 0. ),
+            fCurrentFrequency( 0. ),
+            fStartElectronPosition( 0., 0., 0. ),
+            fUseEnergyDistribution(false),
+            fUseFrequencyDistribution(false),
+            fNTracks(0)
+
+    {
+        fRequiredSignalState = Signal::kTime;
+    }
+
+    FakeFreeSpaceSignalGenerator::~FakeFreeSpaceSignalGenerator()
+    {
+    }
+
+    bool FakeFreeSpaceSignalGenerator::Configure( const scarab::param_node& aParam )
+    {
+
+        if( aParam.has( "start-frequency" ) )
+        {
+            fStartFrequencyDistribution = fDistributionInterface.get_dist(aParam["start-frequency"].as_node());
+            fUseFrequencyDistribution = true;
+        }
+        if( aParam.has( "start-energy" ) )
+        {
+            fStartEnergyDistribution = fDistributionInterface.get_dist(aParam["start-energy"].as_node());
+            fUseEnergyDistribution = true;
+        }
+
+        if( aParam.has( "slope" ) )
+        {
+            fSlopeDistribution = fDistributionInterface.get_dist(aParam["slope"].as_node());
+        }
+        else
+        {
+            LWARN( lmclog, "Using default distribution: Slope = 0 ");
+            scarab::param_node default_setting;
+            default_setting.add("name","dirac");
+            fSlopeDistribution = fDistributionInterface.get_dist(default_setting);
+        }
+
+        if( aParam.has( "radius" ) )
+        {
+            fRadiusDistribution = fDistributionInterface.get_dist(aParam["radius"].as_node());
+        }
+        else
+        {
+            LWARN( lmclog, "Using default distribution: radius = 0 ");
+            scarab::param_node default_setting;
+            default_setting.add("name","dirac");
+            fRadiusDistribution = fDistributionInterface.get_dist(default_setting);
+        }
+
+        if( aParam.has( "radial-phase" ) )
+        {
+            fRadialPhaseDistribution = fDistributionInterface.get_dist(aParam["radial-phase"].as_node());
+        }
+        else
+        {
+            LWARN( lmclog, "Using default distribution: radial-phase = 0 ");
+            scarab::param_node default_setting;
+            default_setting.add("name","dirac");
+            fRadialPhaseDistribution = fDistributionInterface.get_dist(default_setting);
+        }
+
+        if( aParam.has( "track-length" ) )
+        {
+            fTrackLengthDistribution = fDistributionInterface.get_dist(aParam["track-length"].as_node());
+        }
+        else
+        {
+            LWARN( lmclog, "Using default distribution: Track Length = 1e-4 ");
+            scarab::param_node default_setting;
+            default_setting.add("name","dirac");
+            default_setting.add("value","1e-4");
+            fTrackLengthDistribution = fDistributionInterface.get_dist(default_setting);
+        }
+
+        if( aParam.has( "signal-power" ) )
+            SetSignalPower( aParam.get_value< double >( "signal-power", fSignalPower ) );
+
+        if( aParam.has( "start-vphase" ) )
+            SetStartVPhase( aParam.get_value< double >( "start-vphase", fStartVPhase ) );
+
+        if( aParam.has( "start-time-max" ) )
+            SetStartTimeMax( aParam.get_value< double >( "start-time-max", fStartTimeMax ) );
+
+        if( aParam.has( "start-time-min" ) )
+            SetStartTimeMin( aParam.get_value< double >( "start-time-min", fStartTimeMin ) );
+
+        if( aParam.has( "lo-frequency" ) )
+            SetLOFrequency( aParam.get_value< double >( "lo-frequency", fLO_frequency ) );
+
+        if (aParam.has( "ntracks-mean") )
+            SetNTracksMean( aParam.get_value< double >( "ntracks-mean",fNTracksMean) );
+
+        if (aParam.has("magnetic-field") )
+            SetBField(  aParam.get_value< double >("magnetic-field", fBField) );
+
+        if( aParam.has( "antenna-radius" ) )
+            SetAntennaRadius( aParam.get_value< double >( "antenna-radius", fAntennaRadius ) );
+
+        if( aParam.has( "grad-B-frequency" ) )
+            SetGradBFrequency( aParam.get_value< double >( "grad-B-frequency", fGradBFrequency ) );
+        if (aParam.has( "random-seed") )
+            SetRandomSeed(  aParam.get_value< int >( "random-seed",fRandomSeed) );
+
+        if (aParam.has( "n-events") )
+            SetNEvents(  aParam.get_value< int >( "n-events",fNEvents) );
+
+        if( aParam.has( "root-filename" ) )
+        {
+            fRootFilename = aParam["root-filename"]().as_string();
+        }
+
+        if(fRandomSeed)
+            fRandomEngine.seed(fRandomSeed);
+        else
+        {
+            std::random_device rd;
+            fRandomEngine.seed(rd());
+        }
+
+        fDistributionInterface.SetSeed(fRandomSeed);
+
+        if( fUseFrequencyDistribution && fUseEnergyDistribution)
+            LERROR( lmclog, "User specified both start frequency and start energy distribution! Please specify only one!");
+
+        if( ! (fUseFrequencyDistribution || fUseEnergyDistribution))
+        {
+            LWARN( lmclog, "Using default distribution: Frequency = fLO + 50 MHz ");
+            scarab::param_node default_setting;
+            default_setting.add("name","dirac");
+            default_setting.add("value",fLO_frequency + 50e6);
+            fStartFrequencyDistribution = fDistributionInterface.get_dist(default_setting);
+            fUseFrequencyDistribution = true;
+        }
+
+        if( aParam.has( "domain" ) )
+        {
+            string domain = aParam["domain"]().as_string();
+            if( domain == "time" )
+            {
+                SetDomain( Signal::kTime );
+                LDEBUG( lmclog, "Domain is equal to time.");
+            }
+            else if( domain == "freq" )
+            {
+                SetDomain( Signal::kFreq );
+            }
+            else
+            {
+                LERROR( lmclog, "Unable to use domain requested: <" << domain << ">" );
+                return false;
+            }
+        }
+
+
+        return true;
+    }
+
+    void FakeFreeSpaceSignalGenerator::Accept( GeneratorVisitor* aVisitor ) const
+    {
+        aVisitor->Visit( this );
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetSignalPower() const
+    {
+        return fSignalPower;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetSignalPower( double aPower )
+    {
+        fSignalPower = aPower;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetStartVPhase() const
+    {
+        return fStartVPhase;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetStartVPhase( double aPhase )
+    {
+        fStartVPhase = aPhase;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetStartTimeMin() const
+    {
+        return fStartTimeMin;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetStartTimeMin( double aTimeMin )
+    {
+        fStartTimeMin = aTimeMin;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetStartTimeMax() const
+    {
+        return fStartTimeMax;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetStartTimeMax( double aTimeMax )
+    {
+        fStartTimeMax = aTimeMax;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetLOFrequency() const
+    {
+        return fLO_frequency;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetLOFrequency( double aFrequency )
+    {
+        fLO_frequency = aFrequency;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetNTracksMean() const
+    {
+        return fNTracksMean;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetNTracksMean( double aNTracksMean )
+    {
+        fNTracksMean = aNTracksMean;
+        return;
+    }
+
+
+    double FakeFreeSpaceSignalGenerator::GetBField() const
+    {
+        return fBField;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetBField( double aBField )
+    {
+        fBField = aBField;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetAntennaRadius() const
+    {
+        return fAntennaRadius;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetAntennaRadius( double aAntennaRadius )
+    {
+        fAntennaRadius = aAntennaRadius;
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::GetGradBFrequency() const
+    {
+        return fGradBFrequency;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetGradBFrequency( double aGradBFrequency )
+    {
+        fGradBFrequency = aGradBFrequency;
+        return;
+    }
+
+    int FakeFreeSpaceSignalGenerator::GetRandomSeed() const
+    {
+        return fRandomSeed;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetRandomSeed( int aRandomSeed )
+    {
+        fRandomSeed = aRandomSeed;
+        return;
+    }
+    
+    int FakeFreeSpaceSignalGenerator::GetNEvents() const
+    {
+        return fNEvents;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetNEvents( int aNEvents )
+    {
+        fNEvents = aNEvents;
+        return;
+    }
+
+    Signal::State FakeFreeSpaceSignalGenerator::GetDomain() const
+    {
+        return fRequiredSignalState;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetDomain( Signal::State aDomain )
+    {
+        if( aDomain == fRequiredSignalState ) return;
+        fRequiredSignalState = aDomain;  // pls changed == to =.
+        if( fRequiredSignalState == Signal::kTime )
+        {
+            fDoGenerateFunc = &FakeFreeSpaceSignalGenerator::DoGenerateTime;
+        }
+        else if( fRequiredSignalState == Signal::kFreq )
+        {
+            fDoGenerateFunc = &FakeFreeSpaceSignalGenerator::DoGenerateFreq;
+        }
+        else
+        {
+            LWARN( lmclog, "Unknown domain requested: " << aDomain );
+        }
+        return;
+    }
+
+    double FakeFreeSpaceSignalGenerator::rel_cyc(const double& aEnergy, const double& aMagneticField) const
+    {
+        double tCycFreq = LMCConst::Q() * aMagneticField / LMCConst::M_el_kg();
+        return tCycFreq / ( 1. + (aEnergy/LMCConst::M_el_eV()) ) / (2. * LMCConst::Pi()); // takes energy in eV, magnetic field in T, returns in Hz
+    }
+
+    double FakeFreeSpaceSignalGenerator::rel_energy(const double& aFrequency, const double& aMagneticField) const
+    {
+        double tGamma = LMCConst::Q() * aMagneticField / (2. * LMCConst::Pi() * aFrequency * LMCConst::M_el_kg()); //omega = q B / m Gamma
+        return (tGamma - 1.) *LMCConst::M_el_eV(); // takes frequency in Hz, magnetic field in T, returns in kinetic energy eV
+    }
+
+    LMCThreeVector FakeFreeSpaceSignalGenerator::GetElectronPosition(const double& aElectronTime, const LMCThreeVector& aElectronStartPosition)
+    {
+        double tRadialPhase = aElectronStartPosition.AzimuthalAngle();
+        tRadialPhase += 2. * LMCConst::Pi() * fGradBFrequency * aElectronTime;
+        return LMCThreeVector({fRadius * cos(tRadialPhase), fRadius * sin(tRadialPhase),0.});
+
+    }
+
+
+
+    double FakeFreeSpaceSignalGenerator::GetCRESPhase(const double& aElectronTime, const LMCThreeVector& aElectronPosition, const unsigned& channelIndex  )
+    {
+        PatchAntenna *currentPatch;
+        currentPatch = &allChannels[channelIndex][0];  // only 1 slot / patch per channel
+        
+        LMCThreeVector tElectronAntenna = currentPatch->GetPosition() - aElectronPosition;
+
+        double rRadius = tElectronAntenna.Magnitude();
+        double tCurrentTheta = tElectronAntenna.AzimuthalAngle();
+
+        double tCurrentAngularFrequency = 2. * LMCConst::Pi() * fCurrentFrequency;
+
+        double tRetarded = aElectronTime - rRadius / LMCConst::C();
+        return tCurrentAngularFrequency * tRetarded  - tCurrentTheta + fStartVPhase;
+        
+
+    }
+
+
+    double FakeFreeSpaceSignalGenerator::GetCRESAmplitude(const LMCThreeVector& aElectronPosition, const unsigned channelIndex  ) 
+    {
+        PatchAntenna *currentPatch;
+        currentPatch = &allChannels[channelIndex][0];  // only 1 slot / patch per channel
+        const double tResistance = 50.; //Default electronic resistance antenna array (ohms)
+        
+        LMCThreeVector tElectronAntenna = currentPatch->GetPosition() - aElectronPosition;
+        double rRadius = tElectronAntenna.Magnitude();
+
+        return sqrt(tResistance * fSignalPower) / rRadius;
+    }
+
+    void FakeFreeSpaceSignalGenerator::InitializeAntennaArray()
+    {
+        const unsigned nChannels = fNChannels;
+        const double patchRadius = fAntennaRadius;
+        double theta;
+        const double dThetaArray = 2. * LMCConst::Pi() / nChannels; //Divide the circle into nChannels
+
+        PatchAntenna modelPatch;
+
+        allChannels.resize(nChannels);
+        std::cout<<"aa"<<std::endl;
+
+        for(int channelIndex = 0; channelIndex < nChannels; ++channelIndex)
+        {
+            theta = channelIndex * dThetaArray;
+
+            modelPatch.SetCenterPosition({patchRadius * cos(theta) , patchRadius * sin(theta) , 0. }); 
+            modelPatch.SetPolarizationDirection({sin(theta), -cos(theta), 0.}); 
+            modelPatch.SetNormalDirection({-cos(theta), -sin(theta), 0.}); //Say normals point inwards
+            allChannels[channelIndex].AddReceiver(modelPatch);
+        }
+        std::cout<<allChannels[0][0].GetPosition().X()<<std::endl;
+    }
+
+    void FakeFreeSpaceSignalGenerator::SetTrackProperties(Track &aTrack, int TrackID, double aTimeOffset)
+    {
+        double current_energy = 0.;
+        double energy_loss = 0.;
+        double new_energy = 0.;
+
+        std::uniform_real_distribution<double> starttime_distribution(fStartTimeMin,fStartTimeMax);
+        std::uniform_real_distribution<double> dist(0,1);
+
+        if(TrackID==0)
+        {
+            if (aTimeOffset==0) // first event
+        	{
+                fStartTime = starttime_distribution(fRandomEngine);
+        	}
+            else
+            {
+                fStartTime = aTimeOffset;
+            }
+
+            if(fUseFrequencyDistribution)
+            {
+                fStartFrequency = fStartFrequencyDistribution->Generate();
+            }
+            else
+            {
+                fStartFrequency = rel_cyc(fStartEnergyDistribution->Generate(), fBField);
+            }
+
+            fRadius = fRadiusDistribution->Generate();
+            fRadialPhase = fRadialPhaseDistribution->Generate();
+
+            aTrack.Radius = fRadius;
+            aTrack.RadialPhase = fRadialPhase;
+            aTrack.StartTime = fStartTime;
+            aTrack.StartFrequency = fStartFrequency;
+        }
+
+       else
+       {
+            fStartTime = fEndTime + 0.;  // old track endtime + margin=0.
+            current_energy = rel_energy(fCurrentFrequency, fBField); // convert current frequency to energy
+
+            energy_loss = 10.; //hardcoded jump (for now)
+            new_energy = current_energy - energy_loss; // new energy after loss, in eV
+            fStartFrequency = rel_cyc(new_energy, fBField);
+            fCurrentFrequency = fStartFrequency;
+            aTrack.StartTime = fEndTime + 0.; // margin of time is 0.
+            aTrack.StartFrequency = fStartFrequency;
+        }
+
+        fSlope = fSlopeDistribution->Generate();
+
+        fTrackLength = fTrackLengthDistribution->Generate();
+        fEndTime = fStartTime + fTrackLength;  // reset endtime.
+        aTrack.Slope = fSlope;
+        aTrack.TrackLength = fTrackLength;
+        aTrack.EndTime = aTrack.StartTime + aTrack.TrackLength;
+        aTrack.LOFrequency = fLO_frequency;
+        aTrack.TrackPower = fSignalPower;
+        aTrack.StartFrequency = aTrack.StartFrequency;
+    }
+
+
+    void FakeFreeSpaceSignalGenerator::InitiateEvent(Event* anEvent, int eventID)
+    {
+        int random_seed_val;
+        if ( fRandomSeed != 0 )
+        {
+            random_seed_val = fRandomSeed;
+        }
+        else
+        {
+            std::random_device rd;
+            random_seed_val = rd();
+        }
+
+        std::geometric_distribution<int> ntracks_distribution(1./fNTracksMean);
+        fNTracks = ntracks_distribution(fRandomEngine)+1;
+
+        anEvent->fEventID = eventID;
+        anEvent->fLOFrequency = fLO_frequency;
+        anEvent->fRandomSeed = random_seed_val;
+    }
+
+    bool FakeFreeSpaceSignalGenerator::DoGenerate( Signal* aSignal )
+    {
+        return (this->*fDoGenerateFunc)( aSignal );
+    }
+
+
+
+    bool FakeFreeSpaceSignalGenerator::DoGenerateTime( Signal* aSignal )
+    {
+        InitializeAntennaArray();
+
+    	FileWriter* aRootTreeWriter = RootTreeWriter::get_instance();
+    	aRootTreeWriter->SetFilename(fRootFilename);
+        aRootTreeWriter->OpenFile("RECREATE");
+
+        const unsigned nChannels = fNChannels;
+        const double tLocustStep = 1./aSignal->DecimationFactor()/(fAcquisitionRate*1.e6);
+        double tTimeOffset = 0;
+        const int signalSize = aSignal->TimeSize();
+        double tAmplitude, tPhase;
+
+        for(unsigned eventID = 0; eventID < fNEvents; ++eventID)// event loop.
+        {
+            Event* anEvent = new Event();
+            InitiateEvent(anEvent, eventID);
+            Track aTrack;
+            SetTrackProperties(aTrack, 0, tTimeOffset);
+            anEvent->AddTrack(aTrack);
+            
+            unsigned tTrackIndex = 0;
+
+            while( tTrackIndex < anEvent->fNTracks) //loop over tracks in event
+            {
+
+                for(unsigned tChannelIndex = 0; tChannelIndex < nChannels; ++tChannelIndex) // over all channels
+                {
+                	double LO_phase = 0.;
+                    double tElectronTime = 0.;
+                    unsigned tTrackIndexRange[2] = {static_cast<unsigned>(fStartTime / tLocustStep), static_cast<unsigned>(fEndTime / tLocustStep)};
+                    tTrackIndexRange[1] = std::min(tTrackIndexRange[1], aSignal->TimeSize()*aSignal->DecimationFactor());
+                    fCurrentFrequency = fStartFrequency;
+
+                    for( unsigned index = tTrackIndexRange[0]; index < tTrackIndexRange[1]; ++index ) // advance sampling time
+                    {
+                        tAmplitude = GetCRESAmplitude(fStartElectronPosition, tChannelIndex);
+                        tPhase = GetCRESPhase(tElectronTime, fStartElectronPosition, tChannelIndex);
+                        LO_phase += 2.*LMCConst::Pi()*fLO_frequency * tLocustStep;
+                        fCurrentFrequency += fSlope * 1.e6/1.e-3 * tLocustStep;
+
+                        aSignal->LongSignalTimeComplex()[tChannelIndex*aSignal->TimeSize()*aSignal->DecimationFactor() + index][0] += tAmplitude * cos(tPhase-LO_phase);
+                        aSignal->LongSignalTimeComplex()[tChannelIndex*aSignal->TimeSize()*aSignal->DecimationFactor() + index][1] += tAmplitude * cos(-LMCConst::Pi()/2. + tPhase-LO_phase);
+
+                        tElectronTime += tLocustStep;
+                    }
+
+                } //channel loop
+
+                ++tTrackIndex;
+                tTimeOffset = fEndTime;
+                SetTrackProperties(aTrack, tTrackIndex, tTimeOffset);
+                anEvent->AddTrack(aTrack);
+
+            } //track loop
+
+            aRootTreeWriter->WriteEvent(anEvent);
+            delete anEvent;
+        } //event loop
+
+        aRootTreeWriter->CloseFile();
+
+        return true;
+    }
+
+    bool FakeFreeSpaceSignalGenerator::DoGenerateFreq( Signal* aSignal )
+    {
+        return true;
+    }
+
+} /* namespace locust */

--- a/Source/Generators/LMCFakeFreeSpaceSignalGenerator.cc
+++ b/Source/Generators/LMCFakeFreeSpaceSignalGenerator.cc
@@ -559,6 +559,7 @@ namespace locust
                     unsigned tTrackIndexRange[2] = {static_cast<unsigned>(fStartTime / tLocustStep), static_cast<unsigned>(fEndTime / tLocustStep)};
                     tTrackIndexRange[1] = std::min(tTrackIndexRange[1], aSignal->TimeSize()*aSignal->DecimationFactor());
                     fCurrentFrequency = fStartFrequency;
+                    fCurrentRadialPhase = fStartRadialPhase;
 
                     for( unsigned index = tTrackIndexRange[0]; index < tTrackIndexRange[1]; ++index ) // advance sampling time
                     {

--- a/Source/Generators/LMCFakeFreeSpaceSignalGenerator.cc
+++ b/Source/Generators/LMCFakeFreeSpaceSignalGenerator.cc
@@ -407,7 +407,7 @@ namespace locust
         LMCThreeVector tElectronAntenna = currentPatch->GetPosition() - aElectronPosition;
         double rRadius = tElectronAntenna.Magnitude();
 
-        return sqrt(tResistance * fSignalPower) / rRadius;
+        return sqrt(tResistance * fSignalPower) * fAntennaRadius  / rRadius;
     }
 
     void FakeFreeSpaceSignalGenerator::InitializeAntennaArray()

--- a/Source/Generators/LMCFakeFreeSpaceSignalGenerator.hh
+++ b/Source/Generators/LMCFakeFreeSpaceSignalGenerator.hh
@@ -1,0 +1,169 @@
+/*
+ * LMCFakeFreeSpaceSignalGenerator.hh
+ *
+ *  Created on: Nov. 26, 2020
+ *      Author: buzinsky
+ */
+
+#ifndef LMCFAKEFREESPACESIGNALGENERATOR_HH_
+#define LMCFAKEFREESPACESIGNALGENERATOR_HH_
+
+#include "LMCGenerator.hh"
+#include "LMCEvent.hh"
+#include "LMCRunParameters.hh"
+#include "LMCRootTreeWriter.hh"
+#include "LMCDistributionInterface.hh"
+
+#include "LMCChannel.hh"
+#include "LMCPatchAntenna.hh"
+
+
+#include <random>
+#include <vector>
+
+
+namespace scarab
+{
+    class param_node;
+}
+
+namespace locust
+{
+
+    /*!
+     @class FakeFreeSpaceSignalGenerator
+     @author N. Buzinsky
+
+     @brief Generate custom, aka "fake" Free-Space CRES events.
+
+     @details
+     Operates in time space
+
+     Configuration name: "free-space-fake"
+
+     Available configuration options:
+      - "signal-power": double -- PSD of signal (at 90 degrees) (W/Hz).
+      - "start-vphase": double -- Starting voltage phase (V).
+      - "lo-frequency": double -- Frequency of local oscillator (Hz).
+      - "start-time-max": double -- Upper bound for track start time (s); distribution: uniform.
+      - "start-time-min": double -- Lower bound for track start time (s); distribution: uniform.
+      - "magnetic-field": double -- Magnetic field used to convert from frequency to energy (for jumpsize) (T).
+      - "n-events": int -- Number of events per simulation, spaced by 0.5 ms (hardcoded).
+      - "random-seed": integer -- integer seed for random number generator for above pdfs, if set to 0 random_device will be used.
+      - "root-filename": string -- Name of output Root file.  This can have the same name as other
+
+    */
+
+    class FakeFreeSpaceSignalGenerator : public Generator
+    {
+        public:
+            FakeFreeSpaceSignalGenerator( const std::string& aName = "free-space-fake" );
+            virtual ~FakeFreeSpaceSignalGenerator();
+
+            bool Configure( const scarab::param_node& aNode );
+
+            void Accept( GeneratorVisitor* aVisitor ) const;
+
+            double GetLOFrequency() const;
+            void SetLOFrequency( double aFrequency );
+
+            double GetSignalPower() const;
+            void SetSignalPower( double aPower );
+
+            double GetStartVPhase() const;
+            void SetStartVPhase( double aPhase );
+
+            double GetStartTimeMax() const;
+            void SetStartTimeMax( double aTimeMax );
+
+            double GetStartTimeMin() const;
+            void SetStartTimeMin( double aTimeMin );
+
+            double GetNTracksMean() const;
+            void SetNTracksMean( double aNTracksMean );
+
+            double GetBField() const;
+            void SetBField( double aBField );
+
+            double GetAntennaRadius() const;
+            void SetAntennaRadius( double aAntennaRadius );
+
+            double GetGradBFrequency() const;
+            void SetGradBFrequency( double aGradBFrequency );
+
+            int GetRandomSeed() const;
+            void SetRandomSeed(  int aRandomSeed );
+
+            int GetNEvents() const;
+            void SetNEvents(  int aNEvents );
+
+            Signal::State GetDomain() const;
+            void SetDomain( Signal::State aDomain );
+
+            double rel_cyc(const double& aEnergy, const double& aMagneticField) const;
+            double rel_energy(const double& aFrequency, const double& aMagneticField) const;
+
+            LMCThreeVector GetElectronPosition(const double& aElectronTime, const LMCThreeVector& aElectronStartPosition);
+
+            double GetCRESAmplitude(const LMCThreeVector& aElectronPosition, const unsigned channelIndex  );
+            double GetCRESPhase(const double& aElectronTime, const LMCThreeVector& aElectronPosition, const unsigned& channelIndex  );
+
+            void SetTrackProperties(Track &aTrack, int TrackID, double aTimeOffset);
+            void InitiateEvent(Event* anEvent, int eventID);
+
+            double fSlope;
+            double fTrackLength;
+            double fStartTime;
+            double fEndTime;
+            double fStartFrequency;
+            double fCurrentFrequency;
+            double fRadius;
+            double fRadialPhase;
+            LMCThreeVector fStartElectronPosition;
+            double fGradBFrequency;
+            int fNTracks;
+
+
+        private:
+            bool DoGenerate( Signal* aSignal );
+            bool DoGenerateTime( Signal* aSignal );
+            bool DoGenerateFreq( Signal* aSignal );
+
+            bool (FakeFreeSpaceSignalGenerator::*fDoGenerateFunc)( Signal* aSignal );
+
+            void InitializeAntennaArray();
+
+            std::vector< Channel<PatchAntenna> > allChannels; //Vector that contains pointer to all channels
+
+
+            double fSignalPower;
+            double fStartVPhase;
+
+            std::shared_ptr< BaseDistribution> fStartEnergyDistribution;
+            std::shared_ptr< BaseDistribution> fStartFrequencyDistribution;
+            std::shared_ptr< BaseDistribution> fSlopeDistribution;
+            std::shared_ptr< BaseDistribution> fRadiusDistribution;
+            std::shared_ptr< BaseDistribution> fRadialPhaseDistribution;
+            std::shared_ptr< BaseDistribution> fTrackLengthDistribution;
+
+            double fStartTimeMax;
+            double fStartTimeMin;
+            double fAntennaRadius;
+            double fLO_frequency;
+            double fNTracksMean;
+            double fBField;
+            int fRandomSeed;
+            int fNEvents;
+
+
+            std::string fRootFilename;
+            std::default_random_engine fRandomEngine;
+            bool fUseEnergyDistribution;
+            bool fUseFrequencyDistribution;
+
+            DistributionInterface fDistributionInterface;
+    };
+
+} /* namespace locust */
+
+#endif /* LMCFAKEFREESPACESIGNALGENERATOR_HH_ */

--- a/Source/Generators/LMCFakeFreeSpaceSignalGenerator.hh
+++ b/Source/Generators/LMCFakeFreeSpaceSignalGenerator.hh
@@ -103,7 +103,7 @@ namespace locust
             double rel_cyc(const double& aEnergy, const double& aMagneticField) const;
             double rel_energy(const double& aFrequency, const double& aMagneticField) const;
 
-            LMCThreeVector GetElectronPosition(const double& aElectronTime, const LMCThreeVector& aElectronStartPosition);
+            LMCThreeVector GetElectronPosition(const double& aRadialPhase);
 
             double GetCRESAmplitude(const LMCThreeVector& aElectronPosition, const unsigned channelIndex  );
             double GetCRESPhase(const double& aElectronTime, const LMCThreeVector& aElectronPosition, const unsigned& channelIndex  );
@@ -118,8 +118,8 @@ namespace locust
             double fStartFrequency;
             double fCurrentFrequency;
             double fRadius;
-            double fRadialPhase;
-            LMCThreeVector fStartElectronPosition;
+            double fStartRadialPhase;
+            double fCurrentRadialPhase;
             double fGradBFrequency;
             int fNTracks;
 

--- a/Source/IO/LMCRootTreeWriter.cc
+++ b/Source/IO/LMCRootTreeWriter.cc
@@ -71,6 +71,8 @@ namespace locust
         aTree->Branch("RandomSeed", &anEvent->fRandomSeed, "RandomSeed/I");
         aTree->Branch("TrackPower", "std::vector<double>", &anEvent->fTrackPowers);
         aTree->Branch("PitchAngles", "std::vector<double>", &anEvent->fPitchAngles);
+        aTree->Branch("Radii", "std::vector<double>", &anEvent->fRadii);
+        aTree->Branch("RadialPhases", "std::vector<double>", &anEvent->fRadialPhases);
         aTree->Fill();
         aTree->Write();
         delete aTree;


### PR DESCRIPTION
I thought this would be low effort & with people actively racing to figure out DBF with grad-B motion, I figured there would be a strong desire to have something decent now, as opposed to something with more features in a month or two.

The code does compile and run fine on my machine (mac). Signals seem to be sensible (below). Axial effects, pitch angle effects, and scattering not included (I put in a hardcoded 10 eV energy loss on scatters). For the non-90 pitch angles, I don't think analysis developed enough where a FTG is worthwhile. We of course can move scattering in, I think its not the immediate feature people are looking at, so its worth stepping back and seeing if there's a modular way to include that scattering code.


**Tests**
Plot of signals from channels 1, 16 in 30 channel array, electron at center (expected from spiral)
![opposite_phases](https://user-images.githubusercontent.com/5600717/100628061-ccd7c080-32f5-11eb-913c-13a98b0a9188.png)

Plot of signals from channels 1, 8 in 30 channel array, electron at r=2cm, phi=0 rad.
![Figure_1](https://user-images.githubusercontent.com/5600717/100628161-e8db6200-32f5-11eb-867d-5412871d1b3c.png)

I think this second plot is the key one, as you can confirm the frequencies are different by looking at where the graphs intersect. The grad-B motion was cranked up by x100 to see the effect in such a short time period

Outside normal review, I have one main request for @psurukuc  : If you run your ellipse producing code on this FTG, do the ellipses match up with your results from the locust LW calculations? Hopefully this isn't too burdensome. If they don't match, my hypothesis that these shifts come from taking the CRES ball and letting normal vector / radius vary is insufficient

If this signal assumption doesn't line up with the more detailed locust simulations, there is still usable stuff here, certain functions would need to be upgraded (not sure how)

Let me know any other thoughts. Thanks
