### PR TITLE
Feature/synchexamples

### DIFF
--- a/Config/FreeSpaceGeometry.xml
+++ b/Config/FreeSpaceGeometry.xml
@@ -1,3 +1,17 @@
+<external_define name="fieldZ" value="0.9583"/>
+
+    <!-- solenoid turns -->
+
+    <external_define name="pinch_turns" value="61.0"/>
+    <external_define name="bathtub_turns" value="51.0"/>
+	<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
+	<external_define name="bathtub" value="0.8"/>  <!-- 1.0 for bathtub, 1.e-5 for harmonic due\
+ to apparent slow performance with 0.0 value -->
+
+<!--  coil currents -->
+<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
+<external_define name="bathtub" value="5.0"/>  <!-- >=1.0 for bathtub, 1.e-5 for harmonic due\
+ to apparent slow performance with 0.0 value -->
 
 
     <!-- pinch coils -->
@@ -82,6 +96,13 @@
 	 />
       </tag>
 
+
+
+
+
+<!--  Patch geometries are optionally included here for generating VTK graphics. -->
+<!--  They are not active in the Kassiopeia simulation. -->
+
 <!--
  <flattened_poly_loop_surface name="patch_surface" z="0." flattened_mesh_count="10" flattened_mesh_power="1.">
         <poly_loop>
@@ -94,58 +115,6 @@
     </flattened_poly_loop_surface>
 -->
 
-<!--
-    <space name="endcap_assembly">
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 45."/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 90."/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 135."/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 180."/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 225."/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 270."/>
-    </surface>
-    <surface name="patch" node="patch_surface">
-    	<transformation rotation_euler="90. 0. 0."/>
-	<transformation displacement="{0.} {0.} {0.0516}"/>
-	<transformation displacement="{0.006} {0.} {0.}"/>
-    	<transformation rotation_euler="0. 0. 315."/>
-    </surface>
-
-    </space>
--->
 
 <!--
     <space name="patch_assembly">
@@ -365,10 +334,6 @@
 
     <space name="project8_assembly">
 
-<!--    <space name="endcap_array" tree="endcap_assembly">
-	<transformation displacement="{0.} {0.} {0.}"/>
-    </space> -->
-
 <!--
     <space name="patch_array" tree="patch_assembly">
 	<transformation displacement="{0.} {0.} {0.}"/>
@@ -438,6 +403,12 @@
             <transformation rotation_axis_angle="[alignment] 90. 90."/>
         </space>
     </space>
+
+    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@upstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
+
+    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@center_pinch_coil_tag" current="{ [pinch] * [pinch_turns] }"/> 
+
+    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@downstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
 
 
 

--- a/Config/JustKass.xml.in
+++ b/Config/JustKass.xml.in
@@ -1,44 +1,9 @@
-
-<!-- verbosity -->
-<messages>
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="debug" log="warning"/>
-
-    <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
-    <message key="kg_mesh" terminal="normal" log="warning"/>
-    <message key="kg_axial_mesh" terminal="normal" log="warning"/>
-
-	<message key="ks_object" terminal="normal" log="normal"/>
-    <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
-    <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
-    <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
-
-</messages>
-
-
+	
 <!-- parameters -->
 
-
 <external_define name="simulation" value="1"/>
-<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
-<external_define name="bathtub" value="0.45"/>  <!-- 1.0 for bathtub, 1.e-5 for harmonic due\
- to apparent slow performance with 0.0 value -->
 
-<external_define name="fieldZ" value="0.9583"/> <!-- no tilt -->
-<!--<external_define name="fieldZ" value="0.9581540"/> -->
-<external_define name="fieldX" value="0.0"/>  <!-- earth's horiz. field in Seattle -->
+<external_define name="fieldX" value="0.0"/>
 <external_define name="fieldY" value="0.0"/>
 
 <external_define name="alignment" value="0."/>
@@ -55,35 +20,15 @@
 <external_define name="seed" value="112377"/>
 
 <external_define name="output_path" value="${CMAKE_INSTALL_PREFIX}/output"/> 
-<external_define name="file" value="Phase1Seed[seed]Output"/>
+<external_define name="file" value="WaveguideSeed[seed]Output"/>
 
 <define name="config_path" value="${CMAKE_INSTALL_PREFIX}/config"/>
 
 
 <geometry>
-    <include name="[config_path]/Project8Phase1Geometry.xml"/>
+    <include name="[config_path]/WaveguideGeometry.xml"/>
 </geometry>
     
-    <!-- solenoid turns -->
-
-    <define name="pinch_turns" value="61.0"/>
-    <define name="bathtub_turns" value="51.0"/>
-
-
-<geometry>
-
-    <!-- electromagnets -->
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@upstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@center_pinch_coil_tag" current="{ [pinch] * [pinch_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@downstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-
-
-</geometry>
-
 
 
 

--- a/Config/JustKassFieldMap.xml.in
+++ b/Config/JustKassFieldMap.xml.in
@@ -2,12 +2,7 @@
 
 
 <external_define name="simulation" value="1"/>
-<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
-<external_define name="bathtub" value="0.8"/>  <!-- 1.0 for bathtub, 1.e-5 for harmonic due\
- to apparent slow performance with 0.0 value -->
 
-<external_define name="fieldZ" value="0.9583"/> <!-- no tilt -->
-<!--<external_define name="fieldZ" value="0.9581540"/> -->
 <external_define name="fieldX" value="0.0"/>  <!-- earth's horiz. field in Seattle -->
 <external_define name="fieldY" value="0.0"/>
 
@@ -34,28 +29,6 @@
     <include name="[config_path]/FreeSpaceGeometry.xml"/>
 </geometry>
     
-
-    <!-- solenoid turns -->
-
-    <define name="pinch_turns" value="61.0"/>
-    <define name="bathtub_turns" value="51.0"/>
-
-
-<geometry>
-
-    <!-- electromagnets -->
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@upstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@center_pinch_coil_tag" current="{ [pinch] * [pinch_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@downstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-
-
-</geometry>
-
-
 
 
  

--- a/Config/LocustKass_FreeSpace_Template.xml.in
+++ b/Config/LocustKass_FreeSpace_Template.xml.in
@@ -1,49 +1,8 @@
 
-<!-- verbosity -->
-
-<!--
-<messages>
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="debug" log="warning"/>
-
-    <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
-    <message key="kg_mesh" terminal="normal" log="warning"/>
-    <message key="kg_axial_mesh" terminal="normal" log="warning"/>
-
-	<message key="ks_object" terminal="normal" log="normal"/>
-    <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
-    <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
-    <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
-
-</messages>
--->
-
 <!-- parameters -->
 
-
-<external_define name="simulation" value="1"/>
-<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
-<external_define name="bathtub" value="5.0"/>  <!-- 1.0 for bathtub, 1.e-5 for harmonic due\
- to apparent slow performance with 0.0 value -->
-
-<external_define name="fieldZ" value="0.9583"/> <!-- no tilt -->
-<!--<external_define name="fieldZ" value="0.9581540"/> -->
-<external_define name="fieldX" value="0.0"/>  <!-- earth's horiz. field in Seattle -->
+<external_define name="fieldX" value="0.0"/>
 <external_define name="fieldY" value="0.0"/>
-
-<external_define name="alignment" value="0."/>
 
  <external_define name="generator" value="gen_uniform"/>
 <!-- <external_define name="generator" value="gen_krypton"/> -->
@@ -52,6 +11,7 @@
 <!-- <external_define name="trajectory" value="trajectory_exact"/> -->
 <!-- <external_define name="trajectory" value="traj_magnetic"/> -->
 <external_define name="cyclotrons" value="1"/>
+<external_define name="alignment" value="0."/>
 
 <external_define name="count" value="1"/>
 <external_define name="seed" value="112377"/>
@@ -66,27 +26,6 @@
     <include name="[config_path]/FreeSpaceGeometry.xml"/>
 </geometry>
     
-    <!-- solenoid turns -->
-
-    <define name="pinch_turns" value="61.0"/>
-    <define name="bathtub_turns" value="51.0"/>
-
-
-<geometry>
-
-    <!-- electromagnets -->
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@upstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@center_pinch_coil_tag" current="{ [pinch] * [pinch_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@downstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-
-
-</geometry>
-
-
 
 
  

--- a/Config/LocustKass_Waveguide_Template.xml.in
+++ b/Config/LocustKass_Waveguide_Template.xml.in
@@ -1,45 +1,9 @@
 
-<!-- verbosity -->
-<!--
-<messages>
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="debug" log="warning"/>
-
-    <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
-    <message key="kg_mesh" terminal="normal" log="warning"/>
-    <message key="kg_axial_mesh" terminal="normal" log="warning"/>
-
-	<message key="ks_object" terminal="normal" log="normal"/>
-    <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
-    <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
-    <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
-
-</messages>
--->
-
 <!-- parameters -->
 
 
 <external_define name="simulation" value="1"/>
-<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
-<external_define name="bathtub" value="0.5"/>  <!-- 1.0 for bathtub, 1.e-5 for harmonic due\
- to apparent slow performance with 0.0 value -->
-
-<external_define name="fieldZ" value="0.9583"/> <!-- no tilt -->
-<!--<external_define name="fieldZ" value="0.9581540"/> -->
-<external_define name="fieldX" value="0.0"/>  <!-- earth's horiz. field in Seattle -->
+<external_define name="fieldX" value="0.0"/>
 <external_define name="fieldY" value="0.0"/>
 
 <external_define name="alignment" value="0."/>
@@ -56,7 +20,7 @@
 <external_define name="seed" value="112377"/>
 
 <external_define name="output_path" value="${CMAKE_INSTALL_PREFIX}/output"/> 
-<external_define name="file" value="Phase1Seed[seed]Output"/>
+<external_define name="file" value="WaveguideSeed[seed]Output"/>
 
 <define name="config_path" value="${CMAKE_INSTALL_PREFIX}/config"/>
 
@@ -65,27 +29,6 @@
     <include name="[config_path]/WaveguideGeometry.xml"/>
 </geometry>
     
-    <!-- solenoid turns -->
-
-    <define name="pinch_turns" value="61.0"/>
-    <define name="bathtub_turns" value="51.0"/>
-
-
-<geometry>
-
-    <!-- electromagnets -->
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@upstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@center_pinch_coil_tag" current="{ [pinch] * [pinch_turns] }"/> 
-
-    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@downstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
-
-
-
-</geometry>
-
-
 
 
  

--- a/Config/LocustWaveguideTemplate.json.in
+++ b/Config/LocustWaveguideTemplate.json.in
@@ -37,7 +37,7 @@
   
     "gaussian-noise":
     {
-    "noise-floor-psd": 2.0e-22,
+    "noise-floor-psd": 2.0e-26,
     "domain": "time"
     },
 

--- a/Config/WaveguideGeometry.xml
+++ b/Config/WaveguideGeometry.xml
@@ -1,3 +1,14 @@
+<external_define name="fieldZ" value="0.9583"/> <!-- no tilt -->
+<external_define name="pinch" value="1.e-5"/> <!-- -1.0 for harmonic, 1.e-5 for bathtub due to apparent slow performance with 0.0 value -->
+<external_define name="bathtub" value="0.5"/>  <!-- 1.0 for bathtub, 1.e-5 for harmonic due\
+ to apparent slow performance with 0.0 value -->
+    <!-- solenoid turns -->
+
+    <define name="pinch_turns" value="61.0"/>
+    <define name="bathtub_turns" value="51.0"/>
+
+
+
 
 	<!-- waveguide -->
 
@@ -101,6 +112,18 @@
             <transformation rotation_axis_angle="[alignment] 90. 90."/>
         </space>
     </space>
+
+    <!-- electromagnets -->
+
+    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@upstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
+
+    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@center_pinch_coil_tag" current="{ [pinch] * [pinch_turns] }"/> 
+
+    <electromagnet name="electromagnet_solenoid" spaces="world/project8/@downstream_bathtub_coil_tag" current="{ [bathtub] * [bathtub_turns] }"/> 
+
+
+
+
 
 
 

--- a/Config/katydid.json.in
+++ b/Config/katydid.json.in
@@ -71,7 +71,7 @@
         
     "egg1":
     {
-        "filename": "${CMAKE_INSTALL_PREFIX}/bin/locust_mc.egg",
+        "filename": "${CMAKE_INSTALL_PREFIX}/output/locust_mc.egg",
         "egg-reader": "egg3",
         "number-of-slices": 3,
         "slice-size": 8192,
@@ -93,7 +93,7 @@
 
     "waterfall-writer":
     {
-        "output-file": "${CMAKE_INSTALL_PREFIX}/bin/katydidwaterfall.root",
+        "output-file": "${CMAKE_INSTALL_PREFIX}/output/katydidwaterfall.root",
         "file-flag": "recreate",
         "min-time": 0.0,
         "max-time": 0.025,
@@ -105,7 +105,7 @@
 
     "writer":
     {
-        "output-file": "${CMAKE_INSTALL_PREFIX}/bin/basic.root",
+        "output-file": "${CMAKE_INSTALL_PREFIX}/output/basic.root",
         "file-flag": "recreate"
     }
 

--- a/Config/plotfieldmap.c.in
+++ b/Config/plotfieldmap.c.in
@@ -51,7 +51,7 @@ TGraph* grField(const char *filename)
 void fieldmap()
 {
 
-    const char *f = "${CMAKE_INSTALL_PREFIX}/FieldLineSeed335Output.root";
+    const char *f = "${CMAKE_INSTALL_PREFIX}/output/FieldLineSeed335Output.root";
 
     TGraph* gr = grField(f);
 


### PR DESCRIPTION
These changes will allow hexbug geometry files to be used in the generic example files for generic Locust-Kass, Kassiopeia tracking, and Kassiopeia field map plotting instead of just in hexbug.