### PR TITLE
change initial electron pitch range

### DIFF
--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -697,7 +697,7 @@ namespace locust
                 double z0 = fz0Distribution->Generate();
                 fPitch = GetPitchAngleZ(fPitch, GetBField(z0), fBField);
 
-            } while(fPitch < fStartPitchMin * deg_to_rad );
+            } while(fPitch < fPitchMin * deg_to_rad );
 
             fRadius = fRadiusDistribution->Generate();
 


### PR DESCRIPTION
Pretty trivial change in convention that Christine suggested in #fake_track_generator channel on Slack
This change is probably more consistent, what I should done in the first place

This seems to work w/o any issues: When I test, I can see in the ROOT file all pitch angles of electrons greater than fPitchMin now, including the first track