### PR TITLE
Feature/ftg aharmonic

### DIFF
--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -658,6 +658,19 @@ namespace locust
         return j0(k_lambda * zMax);
     }
 
+    double FakeTrackSignalGenerator::Z11(double aFrequency, double aRadius)
+    {
+        const double tWaveguideRadius = 0.00502920;
+        double f_c = 1.8412 * LMCConst::C() / (2. * LMCConst::Pi() * tWaveguideRadius);
+
+        double tEnergy = rel_energy(aFrequency,fBField-GetTrapField(0,aRadius));
+        double tGamma = 1. + tEnergy / LMCConst::M_el_eV();
+        double tBeta = sqrt(1. - 1./pow(tGamma,2.));
+
+        double tZ11 = pow(tBeta,2.) / sqrt(1. - pow(f_c / aFrequency,2.));
+        return tZ11;
+    }
+
     double FakeTrackSignalGenerator::RadialPowerCoupling(double radius)
     {
         const double tWaveguideRadius = 0.00502920;
@@ -1000,8 +1013,10 @@ namespace locust
         double coupling;
         if(fAharmonicCorrection)
         {
-            coupling = AharmonicPowerCoupling(fRadius, fPitch) * RadialPowerCoupling(fRadius);
+            double tZRatio = Z11(fStartFrequency,fRadius)/Z11(rel_cyc(18600., fBField),0);
+            coupling = AharmonicPowerCoupling(fRadius, fPitch) * RadialPowerCoupling(fRadius) * sqrt(tZRatio);
             fAharmonicPowerCoupling = coupling;
+
         }
         else
         {
@@ -1017,7 +1032,6 @@ namespace locust
         aTrack.TrackPower = fSignalPower * pow(coupling,2.);
         aTrack.StartFrequency = GetCorrectedFrequency(aTrack.StartFrequency, aTrack.Radius);
         aTrack.PitchAngle = fPitch * 180. / LMCConst::Pi();
-
     }
 
     void FakeTrackSignalGenerator::InitiateEvent(Event* anEvent, int eventID)

--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -182,8 +182,10 @@ namespace locust
 
         if (aParam.has( "aharmonic-correction") )
             SetAharmonicCorrection(  aParam.get_value< bool >( "aharmonic-correction", fAharmonicCorrection) );
+
         if (aParam.has( "pitch-correction") )
             SetPitchCorrection(  aParam.get_value< bool >( "pitch-correction", fPitchCorrection) );
+
         if (aParam.has( "slope-correction") )
             SetSlopeCorrection( aParam.get_value< bool >( "slope-correction",fSlopeCorrection) );
 
@@ -744,8 +746,6 @@ namespace locust
 
         const int nPoints = 100.;
         double tZMax = GetZMax(aTheta, aRadius);
-	//std::cout<<aTheta<<" "<<aRadius<<std::endl;
-	//std::cout<<"zm: "<<tZMax<<std::endl;
         const double dZ = tZMax / nPoints;
         double xDummy;
 	double tDummy = 0;
@@ -832,8 +832,11 @@ namespace locust
             fRadius = fRadiusDistribution->Generate();
 
 	    if(fAharmonicCorrection)
-		    fAharmonicCorrectionFactor = GetAverageMagneticField(fRadius,fPitch) / fBField;
+	    {
+		    double tBDifference = GetAverageMagneticField(fRadius, fPitch) - GetTrapField(0,fRadius) ;
+		    fAharmonicCorrectionFactor = 1. - tBDifference / fBField;
 
+	    }
             aTrack.Radius = fRadius;
             aTrack.StartTime = fStartTime;
             aTrack.StartFrequency = fStartFrequency;
@@ -860,7 +863,12 @@ namespace locust
             new_energy = current_energy - energy_loss; // new energy after loss, in eV
             fStartFrequency = rel_cyc(new_energy, fBField);
             fCurrentFrequency = fStartFrequency;
-	    fAharmonicCorrectionFactor = GetAverageMagneticField(fRadius,fPitch) / fBField;
+	    if(fAharmonicCorrection)
+	    {
+	        double tBDifference = GetAverageMagneticField(fRadius, fPitch) - GetTrapField(0,fRadius) ;
+	        fAharmonicCorrectionFactor = 1. - tBDifference / fBField;
+	    }
+
             aTrack.StartTime = fEndTime + 0.; // margin of time is 0.
             aTrack.StartFrequency = fStartFrequency;
         }

--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -757,10 +757,12 @@ namespace locust
         for(unsigned i=0; i<nPoints; ++i)
         {
             double tZi = i * dZ; 
-            tBFields.push_back(GetTrapField(tZi, aRadius));
 
             xDummy = v0 * dZ * sqrt(1. - pow(sin(aTheta),2.) * (fBField - GetTrapField(tZi, aRadius)) / (fBField - GetTrapField(0,aRadius)));
             tDummy += 1./ xDummy;
+            if(isnan(tDummy)) break;
+
+            tBFields.push_back(GetTrapField(tZi, aRadius));
             tTimes.push_back(tDummy);
         }
 
@@ -833,9 +835,8 @@ namespace locust
 
 	    if(fAharmonicCorrection)
 	    {
-		    double tBDifference = GetAverageMagneticField(fRadius, fPitch) - GetTrapField(0,fRadius) ;
+		    double tBDifference = GetAverageMagneticField(fRadius, fPitch) - GetTrapField(0,0);
 		    fAharmonicCorrectionFactor = 1. - tBDifference / fBField;
-
 	    }
             aTrack.Radius = fRadius;
             aTrack.StartTime = fStartTime;
@@ -865,7 +866,7 @@ namespace locust
             fCurrentFrequency = fStartFrequency;
 	    if(fAharmonicCorrection)
 	    {
-	        double tBDifference = GetAverageMagneticField(fRadius, fPitch) - GetTrapField(0,fRadius) ;
+	        double tBDifference = GetAverageMagneticField(fRadius, fPitch) - GetTrapField(0,0);
 	        fAharmonicCorrectionFactor = 1. - tBDifference / fBField;
 	    }
 

--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -710,7 +710,7 @@ namespace locust
 
         std::vector<double> tBDifference;
         for(double z=0; z < tZMaxMax; z+=dZ)
-            tBDifference.push_back(fabs( tBMax - GetTrapField(z,aRadius)) );
+            tBDifference.push_back(fabs( -tBMax + fBField - GetTrapField(z,aRadius)) );
 
         int tTurningPointIndex = std::min_element(tBDifference.begin(),tBDifference.end()) - tBDifference.begin();
 
@@ -724,8 +724,11 @@ namespace locust
 
         const int nPoints = 100.;
         double tZMax = GetZMax(aTheta, aRadius);
+	//std::cout<<aTheta<<" "<<aRadius<<std::endl;
+	//std::cout<<"zm: "<<tZMax<<std::endl;
         const double dZ = tZMax / nPoints;
-        double tDummy, xDummy;
+        double xDummy;
+	double tDummy = 0;
         double v0 = 0.25 * 3e8;
 
         for(unsigned i=0; i<nPoints; ++i)
@@ -733,9 +736,9 @@ namespace locust
             double tZi = i * dZ; 
             tBFields.push_back(GetTrapField(tZi, aRadius));
 
-            xDummy = v0 * sqrt(1 - pow(sin(aTheta),2.) * (fBField - GetTrapField(tZi, aRadius)) / (fBField - GetTrapField(0,aRadius))) * dZ;
-            tDummy = 1./ xDummy;
-            tTimes.push_back(tTimes.back() + tDummy);
+            xDummy = v0 * dZ * sqrt(1. - pow(sin(aTheta),2.) * (fBField - GetTrapField(tZi, aRadius)) / (fBField - GetTrapField(0,aRadius)));
+            tDummy += 1./ xDummy;
+            tTimes.push_back(tDummy);
         }
 
         return std::pair< std::vector<double>, std::vector<double> >(tTimes, tBFields);

--- a/Source/Generators/LMCFakeTrackSignalGenerator.cc
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.cc
@@ -995,13 +995,12 @@ namespace locust
         }
 
         fSlope = fSlopeDistribution->Generate();
-        if(fSlopeCorrection && fAharmonicCorrection) fSlope *= pow(AharmonicPowerCoupling(fRadius, fPitch),2.);
-        else if(fSlopeCorrection) fSlope *= pow(RadialPowerCoupling(fRadius),2.);
+        if(fSlopeCorrection) fSlope *= pow(RadialPowerCoupling(fRadius),2.);
 
         double coupling;
         if(fAharmonicCorrection)
         {
-            coupling = AharmonicPowerCoupling(fRadius, fPitch);
+            coupling = AharmonicPowerCoupling(fRadius, fPitch) * RadialPowerCoupling(fRadius);
             fAharmonicPowerCoupling = coupling;
         }
         else

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -112,7 +112,7 @@ namespace locust
             void SetPitchCorrection(  bool aPitchCorrection );
 
             bool GetAharmonicCorrection() const;
-	    void SetAharmonicCorrection( bool aAharmonicCorrection );
+            void SetAharmonicCorrection( bool aAharmonicCorrection );
 
             bool GetSlopeCorrection() const;
             void SetSlopeCorrection(  bool aSlopeCorrection );
@@ -143,6 +143,9 @@ namespace locust
             double GetBField(double z);
             double GetPitchAngleZ(double theta_i, double B_i, double B_f);
             double GetCorrectedFrequency(double frequency, double radius) const;
+
+            void AddConst(std::vector<double> &aVec, const double aFactor, const double aConst);
+            std::pair<std::vector<double>, std::vector<double> > GetFullCycle(std::pair< std::vector<double>, std::vector<double> > aHarmonicSolver);
 
             double GetTrapField(double aZ , double aRadius) const;
             double GetCoilField(double aR0, double aZ0, double aRadius, double aZ) const;
@@ -190,6 +193,7 @@ namespace locust
             double fBField;
             double fCoilCurrent;
             double fAharmonicCorrectionFactor;
+            double fAharmonicPowerCoupling;
             int fRandomSeed;
             int fNEvents;
             bool fAharmonicCorrection;

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -137,11 +137,11 @@ namespace locust
             double GetPitchAngleZ(double theta_i, double B_i, double B_f);
             double GetCorrectedFrequency(double frequency, double radius) const;
 
-            double GetTrapField(double aZ , double aRadius, double aCurrent=0.3);
-            double GetCoilField(double aR0, double aZ0, double aRadius, double aZ, double aCurrent);
-            std::pair< std::vector<double>, std::vector<double> > GetParticleTimes(double aRadius, double aTheta);
-            double GetZMax(double aTheta, double aRadius);
-            double GetAverageMagneticField(std::vector<double> aTime, std::vector<double> aBField);
+            double GetTrapField(double aZ , double aRadius, double aCurrent=0.3) const;
+            double GetCoilField(double aR0, double aZ0, double aRadius, double aZ, double aCurrent) const;
+            std::pair< std::vector<double>, std::vector<double> > GetParticleTimes(double aRadius, double aTheta) const;
+            double GetZMax(double aTheta, double aRadius) const;
+            double GetAverageMagneticField(double aRadius, double aTheta) const;
 
             double GetAxialFrequency();
             void ExtrapolateData(std::vector< std::pair<double, double> > &data, std::array<double, 3> fitPars);

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -111,6 +111,9 @@ namespace locust
             bool GetPitchCorrection() const;
             void SetPitchCorrection(  bool aPitchCorrection );
 
+            bool GetAharmonicCorrection() const;
+	    void SetAharmonicCorrection( bool aAharmonicCorrection );
+
             bool GetSlopeCorrection() const;
             void SetSlopeCorrection(  bool aSlopeCorrection );
 
@@ -181,8 +184,10 @@ namespace locust
             double fLO_frequency;
             double fNTracksMean;
             double fBField;
+            double fAharmonicCorrectionFactor;
             int fRandomSeed;
             int fNEvents;
+            bool fAharmonicCorrection;
             bool fPitchCorrection;
             bool fSlopeCorrection;
             double fHydrogenFraction;

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -16,6 +16,7 @@
 
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_spline.h>
+#include <gsl/gsl_sf_ellint.h>
 
 #include <random>
 #include <vector>
@@ -135,6 +136,12 @@ namespace locust
             double GetBField(double z);
             double GetPitchAngleZ(double theta_i, double B_i, double B_f);
             double GetCorrectedFrequency(double frequency, double radius) const;
+
+            double GetTrapField(double aZ , double aRadius, double aCurrent=0.3);
+            double GetCoilField(double aR0, double aZ0, double aRadius, double aZ, double aCurrent);
+            std::pair< std::vector<double>, std::vector<double> > GetParticleTimes(double aRadius, double aTheta);
+            double GetZMax(double aTheta, double aRadius);
+            double GetAverageMagneticField(std::vector<double> aTime, std::vector<double> aBField);
 
             double GetAxialFrequency();
             void ExtrapolateData(std::vector< std::pair<double, double> > &data, std::array<double, 3> fitPars);

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -137,6 +137,7 @@ namespace locust
             double WaveguidePowerCoupling(double frequency, double pitchAngle);
             double RadialPowerCoupling(double radius);
             double AharmonicPowerCoupling(double aRadius, double aTheta);
+            double Z11(double aFrequency, double aRadius);
             double GetEnergyLoss(double u, bool hydrogenScatter);
 
             double GetKa2(double eLoss, double T);

--- a/Source/Generators/LMCFakeTrackSignalGenerator.hh
+++ b/Source/Generators/LMCFakeTrackSignalGenerator.hh
@@ -120,6 +120,8 @@ namespace locust
             double GetTrapLength() const;
             void SetTrapLength(  double aTrapLength );
 
+            double GetCoilCurrent() const;
+            void SetCoilCurrent(  double aCoilCurrent );
 
             Signal::State GetDomain() const;
             void SetDomain( Signal::State aDomain );
@@ -134,14 +136,16 @@ namespace locust
             void SetInterpolator(gsl_spline*& interpolant, std::vector< std::pair<double, double> > data);
             double WaveguidePowerCoupling(double frequency, double pitchAngle);
             double RadialPowerCoupling(double radius);
+            double AharmonicPowerCoupling(double aRadius, double aTheta);
             double GetEnergyLoss(double u, bool hydrogenScatter);
+
             double GetKa2(double eLoss, double T);
             double GetBField(double z);
             double GetPitchAngleZ(double theta_i, double B_i, double B_f);
             double GetCorrectedFrequency(double frequency, double radius) const;
 
-            double GetTrapField(double aZ , double aRadius, double aCurrent=0.3) const;
-            double GetCoilField(double aR0, double aZ0, double aRadius, double aZ, double aCurrent) const;
+            double GetTrapField(double aZ , double aRadius) const;
+            double GetCoilField(double aR0, double aZ0, double aRadius, double aZ) const;
             std::pair< std::vector<double>, std::vector<double> > GetParticleTimes(double aRadius, double aTheta) const;
             double GetZMax(double aTheta, double aRadius) const;
             double GetAverageMagneticField(double aRadius, double aTheta) const;
@@ -184,6 +188,7 @@ namespace locust
             double fLO_frequency;
             double fNTracksMean;
             double fBField;
+            double fCoilCurrent;
             double fAharmonicCorrectionFactor;
             int fRandomSeed;
             int fNEvents;


### PR DESCRIPTION
Tested, seems to work
Requested from Spectrum Analysis group

Produces about ~1e-6 level corrections for 0.1 deg. pitch angle changes or so (so kHz)
putting pitch angle dependence of freq. shifts for the non-harmonic traps

Tested on latest stable release of Ubuntu (long story)

To @cclaessens Let me know if you will want more control beyond turning off and on, or if the interface makes sense