### PR TITLE
Feature/find skips

### DIFF
--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -462,7 +462,7 @@ namespace locust
  	            double VoltageFIRSample = GetFIRSample(nfilterbins, dtfilter, channelIndex, elementIndex);
             	if ((VoltageFIRSample == 0.)&&(index-startingIndex > fFieldBufferSize*fPowerCombiner->GetNElementsPerStrip()))
             	{
-                    LERROR(lmclog,"A digitizer sample was skipped due to likely unresponsive thread.  Exiting.\n");
+                    LERROR(lmclog,"A digitizer sample was skipped due to likely unresponsive thread.\n");
             		return false;
             	}
  	            fPowerCombiner->AddOneVoltageToStripSum(aSignal, VoltageFIRSample, fphiLO, elementIndex, IndexBuffer[channelIndex*fNElementsPerStrip+elementIndex].front());
@@ -653,9 +653,9 @@ namespace locust
                     		{
                                 PreEventCounter = 0; // reset
                     		}
-                    		else
+                    		else if (!DriveAntenna(fp, startingIndex, index, aSignal, nfilterbins, dtfilter))
                     		{
-                    			LERROR(lmclog,"The antenna did not respond correctly.  Exiting.\n");
+                    			LERROR(lmclog,"The antenna did not respond correctly after two tries.  Exiting.\n");
                     			fSkippedSamples = true;
                                 tLock.unlock();
                     			break;

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -647,7 +647,7 @@ namespace locust
                         fInterface->fDigitizerCondition.wait( tLock );
                         if (fInterface->fEventInProgress)
                         {
-                    		if (!DriveAntenna(fp, startingIndex, index, aSignal, nfilterbins, dtfilter))
+                    		if (DriveAntenna(fp, startingIndex, index, aSignal, nfilterbins, dtfilter))
                     		{
                                 PreEventCounter = 0; // reset
                     		}

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -450,6 +450,7 @@ namespace locust
                 else
                 {
                 	tFieldSolution = fTransmitter->SolveKassFields(currentElement->GetPosition(), currentElement->GetPolarizationDirection(), tReceiverTime, tTotalElementIndex);
+                	if (tFieldSolution[0] == 0.) {printf("field is zero.\n");}
                 }
 
                 tFieldSolution[0] *= currentElement->GetPatternFactor(fTransmitter->GetIncidentKVector(tTotalElementIndex), *currentElement);
@@ -458,6 +459,7 @@ namespace locust
 
  	            FillBuffers(aSignal, tFieldSolution[1], tFieldSolution[0], fphiLO, index, channelIndex, elementIndex);
  	            double VoltageFIRSample = GetFIRSample(nfilterbins, dtfilter, channelIndex, elementIndex);
+            	if (VoltageFIRSample == 0.) {printf("VoltageFIRSample is zero.\n");}
  	            fPowerCombiner->AddOneVoltageToStripSum(aSignal, VoltageFIRSample, fphiLO, elementIndex, IndexBuffer[channelIndex*fNElementsPerStrip+elementIndex].front());
                 PopBuffers(channelIndex, elementIndex);
 

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -460,7 +460,9 @@ namespace locust
  	            double VoltageFIRSample = GetFIRSample(nfilterbins, dtfilter, channelIndex, elementIndex);
             	if ((VoltageFIRSample == 0.)&&(index-startingIndex > fFieldBufferSize*fPowerCombiner->GetNElementsPerStrip()))
             	{
+                    LERROR(lmclog,"A digitizer sample was skipped due to likely unresponsive thread.\n");
             		printf("out of spec at sample %d\n", index);
+            		exit(-1);
             	}
  	            fPowerCombiner->AddOneVoltageToStripSum(aSignal, VoltageFIRSample, fphiLO, elementIndex, IndexBuffer[channelIndex*fNElementsPerStrip+elementIndex].front());
                 PopBuffers(channelIndex, elementIndex);
@@ -661,6 +663,9 @@ namespace locust
                         else  // no Kass event ever started, unlock and break out of signal loop entirely.
                         {
                         	tLock.unlock();
+                			LERROR(lmclog,"No response from Kassiopeia.\n");
+                			printf("no response from Kassiopeia.\n");
+//                			exit(-1);
                         	break;
                         }
                 	}

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -92,6 +92,8 @@ namespace locust
             bool fTextFileWriting;
             unsigned fFieldBufferSize;
             int fSwapFrequency;
+            bool fKassNeverStarted;
+            bool fSkippedSamples;
             double fphiLO; // voltage phase of LO in radians;
 
             void KassiopeiaInit(const std::string &aFile);

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -92,7 +92,6 @@ namespace locust
             bool fTextFileWriting;
             unsigned fFieldBufferSize;
             int fSwapFrequency;
-            int fSkipSampleCheck;
             double fphiLO; // voltage phase of LO in radians;
 
             void KassiopeiaInit(const std::string &aFile);

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -92,6 +92,7 @@ namespace locust
             bool fTextFileWriting;
             unsigned fFieldBufferSize;
             int fSwapFrequency;
+            int fSkipSampleCheck;
             double fphiLO; // voltage phase of LO in radians;
 
             void KassiopeiaInit(const std::string &aFile);
@@ -117,7 +118,7 @@ namespace locust
 
 
             bool DoGenerate( Signal* aSignal );
-            void DriveAntenna(FILE *fp, int PreEventCounter, unsigned index, Signal* aSignal, int nfilterbins, double dtfilter);
+            void DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nfilterbins, double dtfilter);
             bool InitializeElementArray();
             AntennaElementPositioner* fAntennaElementPositioner;
             Transmitter* fTransmitter; // transmitter object

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -117,7 +117,7 @@ namespace locust
 
 
             bool DoGenerate( Signal* aSignal );
-            void DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nfilterbins, double dtfilter);
+            bool DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nfilterbins, double dtfilter);
             bool InitializeElementArray();
             AntennaElementPositioner* fAntennaElementPositioner;
             Transmitter* fTransmitter; // transmitter object

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -31,7 +31,7 @@
 #include "LMCSinglePatchPositioner.hh"
 #include "LMCPlanarArrayPositioner.hh"
 #include <vector>
-
+#include "LMCException.hh"
 
 
 namespace locust

--- a/Source/RxComponents/LMCPowerCombiner.cc
+++ b/Source/RxComponents/LMCPowerCombiner.cc
@@ -77,6 +77,8 @@ namespace locust
 		aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2.*VoltageFIRSample * sin(phi_LO);
 		aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2.*VoltageFIRSample * cos(phi_LO);
 
+		if (VoltageFIRSample==0.) {printf("power combining sees zero.\n");}
+
 		if ( (fvoltageCheck==true) && (sampleIndex%100 < 1) )
 			LWARN( lmclog, "Voltage " << z_index << "  " << sampleIndex << " is <" << aSignal->LongSignalTimeComplex()[sampleIndex][1] << ">" );
 		return true;

--- a/Source/RxComponents/LMCPowerCombiner.cc
+++ b/Source/RxComponents/LMCPowerCombiner.cc
@@ -77,8 +77,6 @@ namespace locust
 		aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2.*VoltageFIRSample * sin(phi_LO);
 		aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2.*VoltageFIRSample * cos(phi_LO);
 
-		if (VoltageFIRSample==0.) {printf("power combining sees zero.\n");}
-
 		if ( (fvoltageCheck==true) && (sampleIndex%100 < 1) )
 			LWARN( lmclog, "Voltage " << z_index << "  " << sampleIndex << " is <" << aSignal->LongSignalTimeComplex()[sampleIndex][1] << ">" );
 		return true;


### PR DESCRIPTION
These updates provide more log messages and clean exits for suspected unresponsive threads on hpc cluster in two cases:
 
1.  The Kassiopeia thread becomes temporarily inaccessible during Locust sampling.
2.  The Kassiopeia thread does not start an event at all.

#1 is a workaround for https://github.com/project8/locust_mc/issues/169 .