### PR TITLE
Feature/exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After running Katydid, the processed fft spectra will have a span from 0 to the 
 
 ### Tutorial
 
-Tutorials with examples are located in the locust-tutorial repository, [here](https://github.com/project8/locust-tutorial). 
+Tutorial documents with examples are located in the locust-tutorial repository, [here](https://github.com/project8/locust-tutorial). 
 
 Issues should be posted via [GitHub](https://github.com/project8/locust_mc/issues).
 
@@ -110,6 +110,15 @@ The following steps will build locust from scratch.  In the terminal:
     $ source /path/to/locust_mc/build/bin/kasperenv.sh 
     ```
   If you have another kassiopeia installation on your computer, you should ensure that locust is not using the environmental variables of the independent kassiopeia installation by removing this line from your .bashrc.
+  
+### Exit codes
+
+When running Locust with Kassiopeia in a shared cluster environment, 2 CPUs may be required unless hyperthreading is enabled on the cluster.  If the level of activity on the cluster is high, thread signals between the separate CPUs can occasionally be missed and an exception will be thrown.  Locust terminates with an integer exception in these two cases:
+
+*  ```exit(2)``` if the Kassiopeia thread did not start.
+*  ```exit(3)``` if a digitizer sample was skipped.  
+
+Immediately after Locust has finished, the exit status can be checked from a bash prompt with ```echo #?```.  If the returned value is zero, then no exception was thrown.  Returned values of 2 or 3 correspond to the exceptions above.  Output egg files are not written if an exception is thrown.
 
 ### Docker container
 

--- a/Source/Applications/LocustSim.cc
+++ b/Source/Applications/LocustSim.cc
@@ -73,6 +73,11 @@ int main( int argc, char** argv )
         LERROR( lmclog, "Exception caught: " << e.what() );
         return -1;
     }
+    catch( int &e )
+    {
+        LERROR( lmclog, "Exception caught: " << e );
+        return e;
+    }
 
     return 0;
 }

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -33,7 +33,7 @@ namespace locust
 		fTextFileWriting( 0 ),
         fphiLO(0.),
 		fNPreEventSamples( 150000 ),
-		fThreadCheckTime(10000),
+		fThreadCheckTime(200),
         EFieldBuffer( 1 ),
         EPhaseBuffer( 1 ),
         EAmplitudeBuffer( 1 ),
@@ -653,9 +653,9 @@ namespace locust
                     		{
                                 PreEventCounter = 0; // reset
                     		}
-                    		else if (!DriveAntenna(fp, startingIndex, index, aSignal, nfilterbins, dtfilter))
+                    		else
                     		{
-                    			LERROR(lmclog,"The antenna did not respond correctly after two tries.  Exiting.\n");
+                    			LERROR(lmclog,"The antenna did not respond correctly.  Exiting.\n");
                     			fSkippedSamples = true;
                                 tLock.unlock();
                     			break;

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -692,8 +692,18 @@ namespace locust
 			fInterface->fWaitBeforeEvent = false;
             WakeBeforeEvent();
             tKassiopeia.join();  // finish thread
-            if (fKassNeverStarted == true) return false;
-            if (fSkippedSamples == true) return false;
+
+            if (fKassNeverStarted == false)
+            {
+            	throw 3;
+            	return false;
+            }
+            if (fSkippedSamples == false)
+            {
+            	throw 2;
+            	return false;
+            }
+
 
 
         }  // fTransmitter->IsKassiopeia()

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -693,14 +693,14 @@ namespace locust
             WakeBeforeEvent();
             tKassiopeia.join();  // finish thread
 
-            if (fKassNeverStarted == false)
-            {
-            	throw 3;
-            	return false;
-            }
-            if (fSkippedSamples == false)
+            if (fKassNeverStarted == true)
             {
             	throw 2;
+            	return false;
+            }
+            if (fSkippedSamples == true)
+            {
+            	throw 3;
             	return false;
             }
 

--- a/Source/Generators/LMCKassSignalGenerator.hh
+++ b/Source/Generators/LMCKassSignalGenerator.hh
@@ -11,9 +11,7 @@
 #include "LMCGenerator.hh"
 
 #include "LMCKassLocustInterface.hh"
-//#include "LMCConst.hh"
-//#include "LMCThreeVector.hh"
-
+#include "LMCException.hh"
 #include <vector>
 using std::vector;
 
@@ -56,7 +54,7 @@ namespace locust
             bool ReceivedKassReady();
 
             bool DoGenerate( Signal* aSignal );
-            void* DriveAntenna(int PreEventCounter, unsigned index, Signal* aSignal, FILE *fp);
+            bool DriveAntenna(int PreEventCounter, unsigned index, Signal* aSignal, FILE *fp);
             int FindNode(double tNew) const;
             double TE11ModeExcitation() const;
             double TE10ModeExcitation() const;
@@ -75,6 +73,8 @@ namespace locust
             mutable int fPreviousRetardedIndex;
             double fEventStartTime;
             bool fEventToFile;
+            bool fKassNeverStarted;
+            bool fSkippedSamples;
             kl_interface_ptr_t fInterface;
 
 


### PR DESCRIPTION
Integer exceptions are thrown for particular failure modes.  The idea is to have the exit codes readable by either e.g. Slurm or Python, or something else, so that the job can be identified and resubmitted if needed.  I am thinking to merge this after we confirm that it is what we want, and that it can work in the script(s).