### PR TITLE
Feature/exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ The following steps will build locust from scratch.  In the terminal:
   
 ### Exit codes
 
-When running Locust with Kassiopeia in a shared cluster environment, 2 CPUs may be required unless hyperthreading is enabled on the cluster.  If the level of activity on the cluster is high, thread signals between the separate CPUs can occasionally be missed and an exception will be thrown.  Locust terminates with an integer exception in these two cases:
+When running Locust with Kassiopeia in a shared cluster environment, 2 CPUs may be required unless hyperthreading is enabled on the cluster.  If the level of activity on the cluster is high, thread signals between the separate CPUs can occasionally be missed and an exception will be thrown.  Locust terminates with an integer exception in these three cases:
 
+*  ```exit(1)``` if the digitizer range was saturated.
 *  ```exit(2)``` if the Kassiopeia thread did not start.
 *  ```exit(3)``` if a digitizer sample was skipped.  
 
-Immediately after Locust has finished, the exit status can be checked from a bash prompt with ```echo #?```.  If the returned value is zero, then no exception was thrown.  Returned values of 2 or 3 correspond to the exceptions above.  Output egg files are not written if an exception is thrown.
+Immediately after Locust has finished, the exit status can be checked from a bash prompt with ```echo #?```.  If the returned value is zero, then no exception was thrown.  Returned values of 1, 2, or 3 correspond to the exceptions above.  Output egg files are not written if an exception is thrown.  Exit codes ```2``` or ```3``` can typically be immediately requeued.  An exit code of ```1``` should be either reconfigured to unsaturate the digitizer, or reported as an issue.
 
 ### Docker container
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ When running Locust with Kassiopeia in a shared cluster environment, 2 CPUs may 
 *  ```exit(2)``` if the Kassiopeia thread did not start.
 *  ```exit(3)``` if a digitizer sample was skipped.  
 
-Immediately after Locust has finished, the exit status can be checked from a bash prompt with ```echo #?```.  If the returned value is zero, then no exception was thrown.  Returned values of 1, 2, or 3 correspond to the exceptions above.  Output egg files are not written if an exception is thrown.  Exit codes ```2``` or ```3``` can typically be immediately requeued.  An exit code of ```1``` should be either reconfigured to unsaturate the digitizer, or reported as an issue.
+Immediately after Locust has finished, the exit status can be checked from a bash prompt with ```echo #?```.  If the returned value is zero, then no exception was thrown.  Returned values of ```1```, ```2```, or ```3``` correspond to the exceptions above.  Output egg files are not written if an exception is thrown.  Exit codes ```2``` or ```3``` can typically be immediately requeued.  An exit code of ```1``` should be either reconfigured to unsaturate the digitizer, or if the digitizer does not appear saturated, reported as an issue.
 
 ### Docker container
 

--- a/Source/Generators/LMCDigitizer.cc
+++ b/Source/Generators/LMCDigitizer.cc
@@ -125,6 +125,14 @@ namespace locust
                     digitizedData[2*ch*signalSize + index*2 ] = a2d< double, uint8_t >( aSignal->SignalTimeComplex()[ch*signalSize + index ][0], &fParams );
                     digitizedData[2*ch*signalSize + index*2+1 ] = a2d< double, uint8_t >( aSignal->SignalTimeComplex()[ch*signalSize + index ][1], &fParams );
 
+                    if ((int(digitizedData[ 2*ch*signalSize + index*2 ]) == 0 ) || ( int(digitizedData[ 2*ch*signalSize + index*2 ] == 255)))
+                    {
+                        LERROR(lmclog,"Digitizer range limit.\n");
+                        printf("Analog data at index %d channel %d is %g\n", index, ch, aSignal->SignalTimeComplex()[ch*signalSize + index ][0]);
+                        printf("Digitized data at index %d channel %d is %d\n", index, ch, digitizedData[2*ch*signalSize + index*2 ]);
+                    	throw 1;
+                    	return false;
+                    }
 
                     if( index < 20 )
                     {

--- a/Source/Generators/LMCDigitizer.cc
+++ b/Source/Generators/LMCDigitizer.cc
@@ -21,6 +21,8 @@ namespace locust
     MT_REGISTER_GENERATOR(Digitizer, "digitizer");
 
     Digitizer::Digitizer( const std::string& aName ) :
+    		fRange( 2.e-8 ),
+			fOffset( -1.e-8 ),
             Generator( aName ),
             fADCValuesSigned( false )
     {
@@ -39,11 +41,11 @@ namespace locust
 
         unsigned bitDepth = aNode.get_value( "bit-depth", fParams.bit_depth );
         unsigned dataTypeSize = aNode.get_value( "data-type-size", fParams.data_type_size );
-        double vRange = aNode.get_value( "v-range", fParams.v_range );
-        double vMin = aNode.get_value( "v-offset", fParams.v_offset );
+        fRange = aNode.get_value( "v-range", fParams.v_range );
+        fOffset = aNode.get_value( "v-offset", fParams.v_offset );
         
 
-        get_calib_params( bitDepth, dataTypeSize, vMin, vRange, false, &fParams );
+        get_calib_params( bitDepth, dataTypeSize, fOffset, fRange, false, &fParams );
 
         LDEBUG( lmclog, "Digitizer calibration parameters set" );
 
@@ -89,6 +91,15 @@ namespace locust
                 
                 digitizedData[2*ch*signalSize + index*2 ] = a2d< double, int8_t >( aSignal->SignalTimeComplex()[ch*signalSize + index ][0], &fParams );
                 digitizedData[2*ch*signalSize + index*2+1 ] = a2d< double, int8_t >( aSignal->SignalTimeComplex()[ch*signalSize + index ][1], &fParams );
+
+                if ((int(digitizedData[ 2*ch*signalSize + index*2 ]) == 0 ) || ( int(digitizedData[ 2*ch*signalSize + index*2 ] == 255)))
+                {
+                    LERROR(lmclog,"Digitizer range limit.\n");
+                    printf("Analog data at index %d channel %d is %g\n", index, ch, aSignal->SignalTimeComplex()[ch*signalSize + index ][0]);
+                    printf("Digitized data at index %d channel %d is %d\n", index, ch, digitizedData[2*ch*signalSize + index*2 ]);
+                	throw 1;
+                	return false;
+                }
 
                 if( index < 10 )
                 {

--- a/Source/Generators/LMCDigitizer.hh
+++ b/Source/Generators/LMCDigitizer.hh
@@ -9,8 +9,8 @@
 #define LMCDIGITIZER_HH_
 
 #include "LMCGenerator.hh"
-
 #include "digital.hh"
+#include "LMCException.hh"
 
 
 
@@ -57,6 +57,10 @@ namespace locust
             struct scarab::dig_calib_params fParams;
 
             bool fADCValuesSigned;
+
+        private:
+            double fRange;
+            double fOffset;
     };
 
     inline void Digitizer::SetADCValuesSigned( bool aFlag )

--- a/Source/Generators/LMCLowPassFilterFFTGenerator.cc
+++ b/Source/Generators/LMCLowPassFilterFFTGenerator.cc
@@ -51,6 +51,37 @@ namespace locust
         return;
     }
 
+// Count leading zeroes in window.
+    int LowPassFilterFFTGenerator::GetStartingMargin( Signal* aSignal, int windowsize, int nwin, int ch )
+    {
+    	int startingMargin = 0;
+    	for (int i=0; i<windowsize; i++)
+    	{
+    		if (fabs(aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + i ][0]) > 0.)
+    		{
+    			startingMargin = i;
+    			break;
+    		}
+    	}
+    	return startingMargin;
+    }
+
+// Count trailing zeroes in window.
+    int LowPassFilterFFTGenerator::GetEndingMargin( Signal* aSignal, int windowsize, int nwin, int ch )
+    {
+    	int endingMargin = 0;
+    	for (int i=0; i<windowsize; i++)
+    	{
+        	if (fabs(aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + (nwin+1)*windowsize - i ][0]) > 0.)
+    		{
+    			endingMargin = i;
+    			break;
+    		}
+    	}
+    	return endingMargin;
+    }
+
+
 
     void LowPassFilterFFTGenerator::Accept( GeneratorVisitor* aVisitor ) const
     {
@@ -75,35 +106,38 @@ namespace locust
         int nwindows = 80;
         int windowsize = aSignal->DecimationFactor()*aSignal->TimeSize()/nwindows;
 
-
-        fftw_complex *SignalComplex;
-        SignalComplex = (fftw_complex*)fftw_malloc( sizeof(fftw_complex) * windowsize );
-        fftw_complex *FFTComplex;
-        FFTComplex = (fftw_complex*)fftw_malloc( sizeof(fftw_complex) * windowsize );
-
-        fftw_plan ForwardPlan;
-        ForwardPlan = fftw_plan_dft_1d(windowsize, SignalComplex, FFTComplex, FFTW_FORWARD, FFTW_ESTIMATE);
-        fftw_plan ReversePlan;
-        ReversePlan = fftw_plan_dft_1d(windowsize, FFTComplex, SignalComplex, FFTW_BACKWARD, FFTW_ESTIMATE);
-
         for (int ch=0; ch<nchannels; ch++)
         {
             for (int nwin = 0; nwin < nwindows; nwin++)
             {
+            	int startingMargin = GetStartingMargin(aSignal, windowsize, nwin, ch);
+            	int endingMargin = GetEndingMargin(aSignal, windowsize, nwin, ch);
+            	int variableWindowSize = windowsize - startingMargin - endingMargin;
+
+                fftw_complex *SignalComplex;
+                SignalComplex = (fftw_complex*)fftw_malloc( sizeof(fftw_complex) * variableWindowSize );
+                fftw_complex *FFTComplex;
+                FFTComplex = (fftw_complex*)fftw_malloc( sizeof(fftw_complex) * variableWindowSize );
+
+                fftw_plan ForwardPlan;
+                ForwardPlan = fftw_plan_dft_1d(variableWindowSize, SignalComplex, FFTComplex, FFTW_FORWARD, FFTW_ESTIMATE);
+                fftw_plan ReversePlan;
+                ReversePlan = fftw_plan_dft_1d(variableWindowSize, FFTComplex, SignalComplex, FFTW_BACKWARD, FFTW_ESTIMATE);
+
                 // Construct complex voltage.
-                for( unsigned index = 0; index < windowsize; ++index )
+                for( unsigned index = 0; index < variableWindowSize; ++index )
                 {
-                    SignalComplex[index][0] = aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index ][0];
-                    SignalComplex[index][1] = aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index ][1];
+                    SignalComplex[index][0] = aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index + startingMargin ][0];
+                    SignalComplex[index][1] = aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index + startingMargin ][1];
                     //if (index==20000) {printf("signal 20000 is %g\n", aSignal->SignalTime()[index]); getchar();}
                 }
 
                 fftw_execute(ForwardPlan);
 
                 // Low Pass FilterFFT
-                for( unsigned index = 0; index < windowsize; ++index )
+                for( unsigned index = 0; index < variableWindowSize; ++index )
                 {
-                	if ( (index > windowsize/2.*CutoffFreq/FastNyquist) && (index < windowsize/2. * (1. + (FastNyquist-CutoffFreq)/FastNyquist)))
+                	if ( (index > variableWindowSize/2.*CutoffFreq/FastNyquist) && (index < variableWindowSize/2. * (1. + (FastNyquist-CutoffFreq)/FastNyquist)))
                 	{
                 		FFTComplex[index][0] = 0.;
                 		FFTComplex[index][1] = 0.;
@@ -114,21 +148,21 @@ namespace locust
 
                 double norm = (double)(windowsize);
 
-                for( unsigned index = 0; index < windowsize; ++index )
+                for( unsigned index = 0; index < variableWindowSize; ++index )
                 {
                     // normalize
-                    aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index ][0] = SignalComplex[index][0]/norm;
-                    aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index ][1] = SignalComplex[index][1]/norm;
+                    aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index + startingMargin ][0] = SignalComplex[index][0]/norm;
+                    aSignal->LongSignalTimeComplex()[ ch*aSignal->TimeSize()*aSignal->DecimationFactor() + nwin*windowsize + index + startingMargin ][1] = SignalComplex[index][1]/norm;
                     //if (index>=20000) {printf("filtered signal is %g\n", aSignal->SignalTime()[index]); getchar();}
                 }
+
+                fftw_destroy_plan(ForwardPlan);
+                fftw_destroy_plan(ReversePlan);
+                delete [] SignalComplex;
+                delete [] FFTComplex;
+
             }  // nwin
         }  // NCHANNELS
-
-        fftw_destroy_plan(ForwardPlan);
-        fftw_destroy_plan(ReversePlan);
-        delete [] SignalComplex;
-        delete [] FFTComplex;
-
 
 
         return true;

--- a/Source/Generators/LMCLowPassFilterFFTGenerator.cc
+++ b/Source/Generators/LMCLowPassFilterFFTGenerator.cc
@@ -115,9 +115,19 @@ namespace locust
         {
             for (int nwin = 0; nwin < nwindows; nwin++)
             {
-            	int startingMargin = GetStartingMargin(aSignal, windowsize, nwin, ch);
+            	int startingMargin = startingMargin = GetStartingMargin(aSignal, windowsize, nwin, ch);
             	int endingMargin = GetEndingMargin(aSignal, windowsize, nwin, ch);
-            	int variableWindowSize = windowsize - startingMargin - endingMargin;
+            	int variableWindowSize = windowsize;
+            	if (!((startingMargin > 0) && (endingMargin > 0)))  // fraction of event is in window
+            	{
+            		variableWindowSize = windowsize - startingMargin - endingMargin;
+            	}
+            	else // accommodate very short test events with zero-noise
+            	{
+            		startingMargin = 0;
+            		endingMargin = 0;
+            	}
+
             	if (variableWindowSize < 1)
             	{
                     LERROR(lmclog,"LPF-FFT variable window size is too small.\n");

--- a/Source/Generators/LMCLowPassFilterFFTGenerator.hh
+++ b/Source/Generators/LMCLowPassFilterFFTGenerator.hh
@@ -49,6 +49,8 @@ class LowPassFilterFFTGenerator : public Generator
 
             bool DoGenerateTime( Signal* aSignal );
             bool DoGenerateFreq( Signal* aSignal );
+            int GetStartingMargin( Signal* aSignal, int windowsize, int nwin, int ch );
+            int GetEndingMargin( Signal* aSignal, int windowsize, int nwin, int ch );
 
             bool (LowPassFilterFFTGenerator::*fDoGenerateFunc)( Signal* aSignal );
 


### PR DESCRIPTION
Removed leading and trailing zeroes from first and last windows in LPF FFT at start and end of signal.  In zero-noise simulations, the beginning or end of the signal can theoretically behave like a signal dropout as has been seen in    https://github.com/project8/locust_mc/issues/169 .  With leading and trailing zeros removed from the FFT, a dropout-like step in the input to the LPF is prevented.

Also implemented a fatal exception for digitizer saturation, regardless of cause (high configured noise power, or other unexpected reason).  

Updated README with new exit code documentation.

    