### PR TITLE
Hotfix/catch early kass terminations

### DIFF
--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -663,27 +663,36 @@ namespace locust
                         }
                         tLock.unlock();
                 	}
-                    else  // Kass event has not started.
-                    {
-                     	if ( fInterface->fEventInProgress )
-                     	{
-                     		if ( index < fNPreEventSamples+1 ) // Kass never started at all.
-                     		{
-                    			LERROR(lmclog,"Kass thread is unresponsive.  Exiting.\n");
-                        		fKassNeverStarted = true;
-                     		}
-                        	tLock.unlock(); // Kass either started or not, but is now finished.
-                        	break;
-                     	}
-                     	else  // Kass started an event and quickly terminated it.
-                     	{
-                    		LWARN(lmclog, "Kass event terminated quickly.\n");
-                    		tLock.unlock();
-                     	}
-                    }
-                }
-            }  // for loop
+                 	else  // diagnose Kass
+                 	{
+                         tLock.lock();
+                         std::this_thread::sleep_for(std::chrono::milliseconds(fThreadCheckTime));
+                         if (!fInterface->fKassEventReady)  // Kass event did start.  Continue but skip this sample.
+                         {
+                         	tLock.unlock();
+                         }
+                         else  // Kass event has not started.
+                         {
+                          	if ( fInterface->fEventInProgress )
+                          	{
+                          		if ( index < fNPreEventSamples+1 ) // Kass never started at all.
+                          		{
+                         			LERROR(lmclog,"Kass thread is unresponsive.  Exiting.\n");
+                             		fKassNeverStarted = true;
+                          		}
+                             	tLock.unlock(); // Kass either started or not, but is now finished.
+                             	break;
+                          	}
+                          	else  // Kass started an event and quickly terminated it.
+                          	{
+                         		LWARN(lmclog, "Kass event terminated quickly.\n");
+                         		tLock.unlock();
+                          	}
+                         }
+                 	} // diagnose Kass
 
+                } // if fEventInProgress
+            }  // for loop
 
             fInterface->fDoneWithSignalGeneration = true;
             if (fTextFileWriting==1) fclose(fp);

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -663,25 +663,24 @@ namespace locust
                         }
                         tLock.unlock();
                 	}
-                	else  // either Kass thread fell behind, or it has stopped generating events.
-                	{
-                        tLock.lock();
-                        std::this_thread::sleep_for(std::chrono::milliseconds(fThreadCheckTime));
-                        if (!fInterface->fKassEventReady)  // Kass event did start.  Continue but skip this sample.
-                        {
-                        	tLock.unlock();
-                        }
-                        else  // Kass event has not started, unlock and exit.
-                        {
-                        	if ( index < fNPreEventSamples+1 )
-                        	{
+                    else  // Kass event has not started.
+                    {
+                     	if ( fInterface->fEventInProgress )
+                     	{
+                     		if ( index < fNPreEventSamples+1 ) // Kass never started at all.
+                     		{
                     			LERROR(lmclog,"Kass thread is unresponsive.  Exiting.\n");
                         		fKassNeverStarted = true;
-                        	}
-                        	tLock.unlock();
+                     		}
+                        	tLock.unlock(); // Kass either started or not, but is now finished.
                         	break;
-                        }
-                	}
+                     	}
+                     	else  // Kass started an event and quickly terminated it.
+                     	{
+                    		LWARN(lmclog, "Kass event terminated quickly.\n");
+                    		tLock.unlock();
+                     	}
+                    }
                 }
             }  // for loop
 

--- a/Source/Generators/LMCKassSignalGenerator.cc
+++ b/Source/Generators/LMCKassSignalGenerator.cc
@@ -358,7 +358,7 @@ namespace locust
                      }
                      tLock.unlock();
              	}
-             	else  // either Kass thread fell behind, or it has stopped generating events.
+             	else  // diagnose Kass
              	{
                      tLock.lock();
                      std::this_thread::sleep_for(std::chrono::milliseconds(fThreadCheckTime));
@@ -366,15 +366,23 @@ namespace locust
                      {
                      	tLock.unlock();
                      }
-                     else  // Kass event has not started, unlock and exit.
+                     else  // Kass event has not started.
                      {
-                     	if ( index < fNPreEventSamples+1 )
-                     	{
-                 			LERROR(lmclog,"Kass thread is unresponsive.  Exiting.\n");
-                     		fKassNeverStarted = true;
-                     	}
-                     	tLock.unlock();
-                     	break;
+                      	if ( fInterface->fEventInProgress )
+                      	{
+                      		if ( index < fNPreEventSamples+1 ) // Kass never started at all.
+                      		{
+                     			LERROR(lmclog,"Kass thread is unresponsive.  Exiting.\n");
+                         		fKassNeverStarted = true;
+                      		}
+                         	tLock.unlock(); // Kass either started or not, but is now finished.
+                         	break;
+                      	}
+                      	else  // Kass started an event and quickly terminated it.
+                      	{
+                     		LWARN(lmclog, "Kass event terminated quickly.\n");
+                     		tLock.unlock();
+                      	}
                      }
              	}
              }


### PR DESCRIPTION
The recent implementation of cluster exception codes inadvertently overkilled Kass events with early terminations (e.g. energy cuts, surface crossings).  The changes in this hotfix allow Kass events with early terminations to finish without throwing a Locust exception.  