### PR TITLE
Install /output directory if building without Kassiopeia.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,3 +204,10 @@ endif (locust_mc_ENABLE_EXECUTABLES )
 
 add_subdirectory( Config )
 
+################
+# Install empty output/ directory if building without Kassiopeia #
+################
+
+install( DIRECTORY DESTINATION ${CMAKE_INSTALL_PREFIX}/output )
+
+


### PR DESCRIPTION
This is a minor change to create a directory output/ for the build without Kass.  If building with Kass, this directory does get installed already.  This addresses https://github.com/project8/locust_mc/issues/177 .