### PR TITLE
Boost build fix for some versions

### DIFF
--- a/Source/RxComponents/LMCPatchAntenna.hh
+++ b/Source/RxComponents/LMCPatchAntenna.hh
@@ -8,6 +8,7 @@
 #ifndef LMCPATCHANTENNA_HH_
 #define LMCPATCHANTENNA_HH_
 
+#include <boost/math/special_functions/trunc.hpp>
 #include <boost/math/interpolators/cubic_b_spline.hpp>
 #include "LMCThreeVector.hh"
 #include "LMCConst.hh"


### PR DESCRIPTION
In some Boost versions a header file is not found unless it is included by name.  It is now included in LMCPatchAntenna.  This addresses https://github.com/project8/locust_mc/issues/191 .