### PR TITLE
Feature/allow long fir

### DIFF
--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -614,7 +614,7 @@ namespace locust
 
         int nFilterBins = fTFReceiverHandler.GetFilterSize();
         double dtFilter = fTFReceiverHandler.GetFilterResolution();
-        int nFilterBinsRequired = 1. / (fAcquisitionRate*1.e6*aSignal->DecimationFactor()) / dtFilter;
+        int nFilterBinsRequired = std::min( 1. / (fAcquisitionRate*1.e6*aSignal->DecimationFactor()) / dtFilter, (double)nFilterBins );
         if (!fAllowFastSampling) nFilterBinsRequired = nFilterBins;
         unsigned nFieldBufferBins = fFieldBufferSize;
         InitializeBuffers(nFilterBins, nFieldBufferBins);

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -395,7 +395,7 @@ namespace locust
 
 
 
-    double ArraySignalGenerator::GetFIRSample(int nFilterBins, int nFilterBinsRequired, double dtFilter, unsigned channel, unsigned element)
+    double ArraySignalGenerator::GetFIRSample(int nFilterBinsRequired, double dtFilter, unsigned channel, unsigned element)
     {
 
     	double fieldfrequency = EFrequencyBuffer[channel*fNElementsPerStrip+element].front();
@@ -444,7 +444,7 @@ namespace locust
     }
 
 
-    bool ArraySignalGenerator::DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nFilterBins, int nFilterBinsRequired, double dtFilter)
+    bool ArraySignalGenerator::DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nFilterBinsRequired, double dtFilter)
     {
 
         const int signalSize = aSignal->TimeSize();
@@ -482,7 +482,7 @@ namespace locust
                 if (fTextFileWriting==1) RecordIncidentFields(fp,  fInterface->fTOld, elementIndex, currentElement->GetPosition().GetZ(), tFieldSolution[1]);
 
  	            FillBuffers(aSignal, tFieldSolution[1], tFieldSolution[0], fphiLO, index, channelIndex, elementIndex);
- 	            double VoltageFIRSample = GetFIRSample(nFilterBins, nFilterBinsRequired, dtFilter, channelIndex, elementIndex);
+ 	            double VoltageFIRSample = GetFIRSample(nFilterBinsRequired, dtFilter, channelIndex, elementIndex);
             	if ((VoltageFIRSample == 0.)&&(index-startingIndex > fFieldBufferSize*fPowerCombiner->GetNElementsPerStrip()))
             	{
                     LERROR(lmclog,"A digitizer sample was skipped due to likely unresponsive thread.\n");
@@ -625,7 +625,7 @@ namespace locust
         {
         	for( unsigned index = 0; index < aSignal->DecimationFactor()*aSignal->TimeSize(); ++index )
         	{
-        		DriveAntenna(fp, PreEventCounter, index, aSignal, nFilterBins, nFilterBinsRequired, dtFilter);
+        		DriveAntenna(fp, PreEventCounter, index, aSignal, nFilterBinsRequired, dtFilter);
         	}  // for loop
         	return true;
         }
@@ -676,7 +676,7 @@ namespace locust
                         fInterface->fDigitizerCondition.wait( tLock );
                         if (fInterface->fEventInProgress)
                         {
-                    		if (DriveAntenna(fp, startingIndex, index, aSignal, nFilterBins, nFilterBinsRequired, dtFilter))
+                    		if (DriveAntenna(fp, startingIndex, index, aSignal, nFilterBinsRequired, dtFilter))
                     		{
                                 PreEventCounter = 0; // reset
                     		}

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -45,6 +45,7 @@ namespace locust
 		fSwapFrequency( 1000 ),
 		fKassNeverStarted( false ),
 		fSkippedSamples( false ),
+		fAllowFastSampling( false ),
 		fInterface( new KassLocustInterface() )
     {
         fRequiredSignalState = Signal::kTime;
@@ -317,6 +318,10 @@ namespace locust
         {
             fTextFileWriting = aParam["text-filewriting"]().as_bool();
         }
+        if( aParam.has( "allow-fast-sampling" ) )
+        {
+            fAllowFastSampling = aParam["allow-fast-sampling"]().as_bool();
+        }
 
         return true;
     }
@@ -393,7 +398,6 @@ namespace locust
     {
 
     	double fieldfrequency = EFrequencyBuffer[channel*fNElementsPerStrip+element].front();
-//    	printf("field frequency is %g\n", fieldfrequency); getchar();
     	double HilbertMag = 0.;
     	double HilbertPhase = 0.;
     	double convolution = 0.0;
@@ -414,8 +418,8 @@ namespace locust
     		}
 
     		convolution=fTFReceiverHandler.ConvolveWithFIRFilter(ElementFIRBuffer[channel*fNElementsPerStrip+element]);
-
     		return convolution;
+
     	}
     	else return 0.;
 
@@ -591,6 +595,7 @@ namespace locust
         int nFilterBins = fTFReceiverHandler.GetFilterSize();
         double dtFilter = fTFReceiverHandler.GetFilterResolution();
         int nFilterBinsRequired = 1. / (fAcquisitionRate*1.e6*aSignal->DecimationFactor()) / dtFilter;
+        if (!fAllowFastSampling) nFilterBinsRequired = nFilterBins;
         unsigned nFieldBufferBins = fFieldBufferSize;
         InitializeBuffers(nFilterBins, nFieldBufferBins);
 

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -50,6 +50,8 @@ namespace locust
      - "zshift-array":  shift of whole antenna array along z axis, for testing (meters).
      - "swap-frequency":  number of digitizer samples after which buffer memory is reset.  This
      	 	 becomes more important for large numbers of patches
+     - "allow-fast-sampling": use sampling interval to define overlap time between incident field and FIR.
+     	 	 default is false, which sets overlap to be the entire duration of FIR.
 
     */
 
@@ -83,6 +85,7 @@ namespace locust
             int fSwapFrequency;
             bool fKassNeverStarted;
             bool fSkippedSamples;
+            bool fAllowFastSampling;
             double fphiLO; // voltage phase of LO in radians;
 
             void KassiopeiaInit(const std::string &aFile);

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -20,6 +20,7 @@
 #include "LMCTFFileHandler.hh"
 #include "LMCKassLocustInterface.hh"
 #include <vector>
+#include <algorithm>    // std::min
 #include "LMCException.hh"
 
 

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -94,7 +94,7 @@ namespace locust
 
         	void InitializeFieldPoints(std::vector< Channel<Receiver*> > allRxChannels);
             void RecordIncidentFields(FILE *fp, double t_old, int patchIndex, double zpatch, double tEFieldCoPol);
-            double GetFIRSample(int nFilterBins, int nFilterBinsRequired, double dtfilter, unsigned channel, unsigned patch);
+            double GetFIRSample(int nFilterBinsRequired, double dtfilter, unsigned channel, unsigned patch);
             void InitializeBuffers(unsigned filterbuffersize, unsigned fieldbuffersize);
             void CleanupBuffers();
             void PopBuffers(unsigned channel, unsigned patch);
@@ -112,7 +112,7 @@ namespace locust
 
 
             bool DoGenerate( Signal* aSignal );
-            bool DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nFilterBins, int nFilterBinsRequired, double dtfilter);
+            bool DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nFilterBinsRequired, double dtfilter);
             bool InitializeElementArray();
             AntennaElementPositioner* fAntennaElementPositioner;
             Transmitter* fTransmitter; // transmitter object

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -94,7 +94,7 @@ namespace locust
 
         	void InitializeFieldPoints(std::vector< Channel<Receiver*> > allRxChannels);
             void RecordIncidentFields(FILE *fp, double t_old, int patchIndex, double zpatch, double tEFieldCoPol);
-            double GetFIRSample(int nfilterbins, double dtfilter, unsigned channel, unsigned patch);
+            double GetFIRSample(int nFilterBins, int nFilterBinsRequired, double dtfilter, unsigned channel, unsigned patch);
             void InitializeBuffers(unsigned filterbuffersize, unsigned fieldbuffersize);
             void CleanupBuffers();
             void PopBuffers(unsigned channel, unsigned patch);
@@ -108,10 +108,11 @@ namespace locust
             std::vector<std::deque<double>> LOPhaseBuffer;
             std::vector<std::deque<unsigned>> IndexBuffer;
             std::vector<std::deque<double>> ElementFIRBuffer;
+            std::vector<std::deque<double>> FIRfrequencyBuffer;
 
 
             bool DoGenerate( Signal* aSignal );
-            bool DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nfilterbins, double dtfilter);
+            bool DriveAntenna(FILE *fp, int startingIndex, unsigned index, Signal* aSignal, int nFilterBins, int nFilterBinsRequired, double dtfilter);
             bool InitializeElementArray();
             AntennaElementPositioner* fAntennaElementPositioner;
             Transmitter* fTransmitter; // transmitter object


### PR DESCRIPTION
These changes include an option "allow-fast-sampling" (default=false) to use fast sampling relative to FIR duration.  In 30 GHz sampling tests using the analytic plane-wave transmitter, the output frequency looks correct, but there is some loss in detected power.  This is likely due to a loss of smooth phase variation between samples inside the FIR convolution.    

If we want to try a high-fidelity fast sampling test in the FSCD, then we probably need a shorter duration FIR to fit the short sampling interval.  On the other hand, if we are only checking output frequencies and features (and not necessarily absolute detected power), then these changes might be sufficient.