### PR TITLE
hotfix/FIR_length

### DIFF
--- a/Source/Transforms/LMCComplexFFT.cc
+++ b/Source/Transforms/LMCComplexFFT.cc
@@ -237,10 +237,11 @@ namespace locust
         }
         for (int i = 0; i < 2*fSize+fNShiftBins; ++i)
         {
-        	out[i][0]=fOutputArray[i][0]*2/fTotalWindowSize;
         }
-        for (int i = 0; i < fSize+2*fNShiftBins; ++i){
-        	}
+        for (int i = 0; i < fSize+2*fNShiftBins; ++i)
+        {
+            out[i][0]=fOutputArray[i][0]*2/fTotalWindowSize;
+        }
         return true;
     }
     


### PR DESCRIPTION
This is a small bug fix that was causing incorrect features in the frequency response of the antenna. The two plots below show the difference between the two, using the flat TF of the isotropic antenna.

![fir_hotfix](https://user-images.githubusercontent.com/4548864/148454992-429193c1-5b1f-4fad-bcdd-3dd5a7e9a138.png)

![fir_hotfix_freq](https://user-images.githubusercontent.com/4548864/148455221-9a72e42a-8efd-4e3d-a8c0-7b73bb065c91.png)

