### PR TITLE
Tukey window had an error

### DIFF
--- a/Source/Transforms/LMCComplexFFT.cc
+++ b/Source/Transforms/LMCComplexFFT.cc
@@ -144,6 +144,7 @@ namespace locust
                 else if(i>midWindowFinalBin && i<=finalWindowFinalBin)
                 {
                     fWindowFunction[i]=0.5*(1 - std::cos( (LMCConst::Pi()*2*(fSize-j)) / (tukeyWindowAlpha*fSize) ) );
+                    j++;
                 }
             }
         }
@@ -151,6 +152,17 @@ namespace locust
         {
             return false;
         }
+        ////////////////////////////
+        //text file for testing.   
+        std::ofstream windowfile;
+        windowfile.open("windowfile.txt");
+        for (int i = 0; i < fTotalWindowSize; ++i)
+        {
+            windowfile << fWindowFunction.at(i);
+            windowfile << "\n";
+        }
+        windowfile.close();
+        ////////////////////////////
         return true;
     }
 

--- a/Source/Transforms/LMCComplexFFT.cc
+++ b/Source/Transforms/LMCComplexFFT.cc
@@ -93,64 +93,65 @@ namespace locust
     bool ComplexFFT::GenerateWindowFunction()
     {
         if(fWindowFunctionType==0)
-	{
+        {
             for (int i = 0; i < fTotalWindowSize; ++i)
             {
-	        fWindowFunction.push_back(0.0);
-	    }
+                fWindowFunction.push_back(0.0);
+            }
             for (int i = 0; i < fTotalWindowSize; ++i)
             {
-		if(i>fPreFilterBins && i<=fPreFilterBins+fSize)
-		{
-	            fWindowFunction[i]=1.0;
-		}
-		else
-		{
-		    fWindowFunction[i]=0.0;
-		}
-	    }
-	}
+                if(i>fPreFilterBins && i<=fPreFilterBins+fSize)
+                {
+                    fWindowFunction[i]=1.0;
+                }
+                else
+                {
+                    fWindowFunction[i]=0.0;
+                }
+            }
+        }
         else if(fWindowFunctionType==1)
-	{
-	    //Tukey window is defined as 
-	    //w[n]=0.5*(1+cos(pi(2n/(alpha*N)-1))); if 0<=n<alpha*N/2
-	    //w[n]= 1; alpha*N/2<=n<=N(1-alpha/2)
-	    //w[n]=0.5*(1+cos(pi(2n/(alpha*N)-2/alpha+1))) if N(1-alpha/2)<n<=N
-	    double tukeyWindowAlpha = 0.5;
-	    int firstWindowFirstBin = fPreFilterBins;
-	    int midWindowFirstBin = fPreFilterBins+tukeyWindowAlpha*fSize/2.0;
-	    int midWindowFinalBin = fPreFilterBins+fSize-tukeyWindowAlpha*fSize/2.0;
-	    int finalWindowFinalBin = fPreFilterBins+fSize;
-	    //std::cout<< "firstWindowFirstBin: "<<firstWindowFirstBin<<std::endl;
-	    //std::cout<< "midWindowFirstBin: "<<midWindowFirstBin<<std::endl;
-	    //std::cout<< "midWindowFinalBin: "<<midWindowFinalBin<<std::endl;
-	    //std::cout<< "finalWindowFinalBin: "<<finalWindowFinalBin<<std::endl;
-            for (int i = 0; i < fTotalWindowSize; ++i)
-            {
-	        fWindowFunction.push_back(0.0);
-	    }
+        {
 
+        // Tukey window is defined as: (wikipedia)
+	    // w[n]=0.5*(1-cos((pi*2*n)/(alpha*N))); if 0<=n<alpha*N/2
+	    // w[n]= 1; alpha*N/2<=n<=N/2
+	    // w[N-n] = w[n] for 0 <= n <= N/2
+
+            double tukeyWindowAlpha = 0.5;
+            int firstWindowFirstBin = fPreFilterBins;
+            int midWindowFirstBin = fPreFilterBins+tukeyWindowAlpha*fSize/2.0;
+            int midWindowFinalBin = fPreFilterBins+fSize-tukeyWindowAlpha*fSize/2.0;
+            int finalWindowFinalBin = fPreFilterBins+fSize;
+
+            int j = 0; // index for the window itself, inside the larger array            
             for (int i = 0; i < fTotalWindowSize; ++i)
             {
-		if(i>fPreFilterBins && i<midWindowFirstBin)
-		{
-	            fWindowFunction[i]=0.5*(1+std::cos(LMCConst::Pi()*(2*i/(tukeyWindowAlpha*fSize)-1)));
-		}
-		else if(i>=midWindowFirstBin && i<=midWindowFinalBin)
-		{
-		    fWindowFunction[i]=1.0;
-		}
-		else if(i>midWindowFinalBin && i<=finalWindowFinalBin)
-		{
-		    fWindowFunction[i]=0.5*(1+std::cos(LMCConst::Pi()*(2*i/(tukeyWindowAlpha*fSize)-1.0/tukeyWindowAlpha+1)));
-		}
-	    }
-	}	
-	else
-	{
-	    return false;
-	}
-	return true;
+                fWindowFunction.push_back(0.0);
+            }
+            for (int i = 0; i < fTotalWindowSize; ++i)
+            {
+                if(i>fPreFilterBins && i<midWindowFirstBin)
+                {
+                    fWindowFunction[i]=0.5*(1 - std::cos( (LMCConst::Pi()*2*j) / (tukeyWindowAlpha*fSize) ) );
+                    j++;
+                }
+                else if(i>=midWindowFirstBin && i<=midWindowFinalBin)
+                {
+                    fWindowFunction[i]=1.0;
+                    j++;
+                }
+                else if(i>midWindowFinalBin && i<=finalWindowFinalBin)
+                {
+                    fWindowFunction[i]=0.5*(1 - std::cos( (LMCConst::Pi()*2*(fSize-j)) / (tukeyWindowAlpha*fSize) ) );
+                }
+            }
+        }
+        else
+        {
+            return false;
+        }
+        return true;
     }
 
     bool ComplexFFT::MakeFilterCausal(fftw_complex* in)


### PR DESCRIPTION
The calculation of the tukey window had an error. I don't think it affected anything up until now because it's off in the 25 GHz and 27 GHz regions. However, it did show up when I did wider frequency sweeps. 

The main issue was that the tukey window calculation is calculated using the sample number in the window. See [the wikipedia page here](https://en.wikipedia.org/wiki/Window_function#Tukey_window). However, our window sits inside of a zero-padded array of much longer length. Up until now, we had been using the index inside of that longer array, causing errors in the calculation of the window. At the default parameter alpha = 0.5 and the default n-shift-bins, these differences were minor, but if you move away from 0.5 then the window becomes completely wrong.

In this hotfix, I introduced a new index into the introduced to keep track of the window itself, rather than the larger zero-padded array that it sits inside of. I will be releasing a feature branch with expanded window capabilities soon, but I figured this should be merged in quickly. Also, I fixed some of the formatting, which is why so many lines are changed in the commit.

Here is a plot of the tukey window before and after the hotfix. Like I said, it's not a very big difference for alpha = 0.5 and a suitable choice of n-shift-bins, but for other values of those parameters it would have a big effect on this plot. The sinusoidal sides of the window wouldn't match up between the floor and the flat top of the window, being in the wrong phase.

![image](https://user-images.githubusercontent.com/4548864/149594278-fa659c1f-f48f-4225-aafe-db59757e689e.png)
![image](https://user-images.githubusercontent.com/4548864/149594289-829c3a2a-b195-4c0d-a95b-bba306a3260b.png)

And this plot shows the difference before and after the hotfix, but with a frequency sweep using the new port TF. The oscillating parts are due to the hilbert transform not having a window function. I'll be addressing that in my next feature branch.
![image](https://user-images.githubusercontent.com/4548864/149594372-781ec584-c286-4921-906a-ebe24644a1df.png)

