### PR TITLE
Feature/e gun

### DIFF
--- a/Config/LocustCavityTemplate.json.in
+++ b/Config/LocustCavityTemplate.json.in
@@ -10,7 +10,7 @@
     "cavity-signal":
     {
         "transmitter": "kass-current",
-	"e-gun": false,
+        "e-gun": false,
         "voltage-check": "true",
         "lo-frequency": 0.98e9,               
         "tf-receiver-filename": "${CMAKE_INSTALL_PREFIX}/data/cavityTF.txt",
@@ -35,8 +35,8 @@
 
     "digitizer":
     {
-    	"v-range":  1.0e-3,
-    	"v-offset": -0.5e-3
+    	"v-range":  10.0e-4,
+    	"v-offset": -5.0e-4
     }
 
 }

--- a/Config/LocustEGunTemplate.json.in
+++ b/Config/LocustEGunTemplate.json.in
@@ -10,8 +10,8 @@
     "cavity-signal":
     {
         "transmitter": "kass-current",
-	"e-gun": true,
-	"central-frequency": 25.9e9,
+        "e-gun": true,
+        "central-frequency": 25.9e9,
         "voltage-check": "true",
         "lo-frequency": 25.8741e9,               
         "tf-receiver-filename": "${CMAKE_INSTALL_PREFIX}/data/WR42_centerline_TF.txt",
@@ -36,8 +36,8 @@
 
     "digitizer":
     {
-    	"v-range":  5.0e-07,
-    	"v-offset": -2.5e-07
+    	"v-range":  5.0e-05,
+    	"v-offset": -2.5e-05
     }
 
 }

--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -79,12 +79,15 @@ namespace locust
 
     double CylindricalCavity::GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP)
     {
-    	return tKassParticleXP[7];  // fcyc
+    	// fix me (placeholder)
+    	return 0.;
+//    	return tKassParticleXP[7];  // fcyc
     }
 
 
     double CylindricalCavity::Z_TE(int l, int m, int n, double fcyc) const
     {
+    	// fix me (placeholder)
     	double Z_TE = 1.0;
     	double x_lm = fInterface->fBesselNKPrimeZeros[l][m];
     	double k1 = x_lm / fInterface->fR;
@@ -100,6 +103,7 @@ namespace locust
 
     double CylindricalCavity::Z_TM(int l, int m, int n, double fcyc) const
     {
+    	// fix me (placeholder)
     	double Z_TM = 1.0;
     	double x_lm = fInterface->fBesselNKZeros[l][m];
     	double k1 = x_lm / fInterface->fR;

--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -23,15 +23,15 @@ namespace locust
 
     	std::vector<double> aField;
     	double r, theta, zPozar, zKass = 0.;
-    	double dR = fInterface->fR/fInterface->fnPixels;
-    	double dZ = fInterface->fL/fInterface->fnPixels;
-    	double dTheta = 2.*LMCConst::Pi()/fInterface->fnPixels;
+    	double dR = fInterface->fR/GetNPixels();
+    	double dZ = fInterface->fL/GetNPixels();
+    	double dTheta = 2.*LMCConst::Pi()/GetNPixels();
     	double tVolume = 0.;
     	double tIntegral = 0.;
 
-    	for (unsigned i=0; i<fInterface->fnPixels; i++)
-    		for (unsigned j=0; j<fInterface->fnPixels; j++)
-    			for (unsigned k=0; k<fInterface->fnPixels; k++)
+    	for (unsigned i=0; i<GetNPixels(); i++)
+    		for (unsigned j=0; j<GetNPixels(); j++)
+    			for (unsigned k=0; k<GetNPixels(); k++)
     			{
     	    		r = (double)i*dR;
     	    		theta = (double)j*dTheta;
@@ -76,6 +76,12 @@ namespace locust
 //    	printf("tVolume is %g\n", tVolume); getchar();
     	return tIntegral;
     }
+
+    double CylindricalCavity::GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP)
+    {
+    	return tKassParticleXP[7];  // fcyc
+    }
+
 
     double CylindricalCavity::Z_TE(int l, int m, int n, double fcyc) const
     {

--- a/Source/Fields/LMCCylindricalCavity.hh
+++ b/Source/Fields/LMCCylindricalCavity.hh
@@ -45,6 +45,7 @@ namespace locust
             double Z_TE(int l, int m, int n, double fcyc) const;
             double Z_TM(int l, int m, int n, double fcyc) const;
             double Integrate(int l, int m, int n, bool teMode, bool eField);
+            double GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP);
 
 
         private:

--- a/Source/Fields/LMCField.cc
+++ b/Source/Fields/LMCField.cc
@@ -12,6 +12,7 @@ namespace locust
 {
     LOGGER( lmclog, "Field" );
     Field::Field():
+		fnPixels( 100 ),
     	fCentralFrequency(0.)
     {}
     Field::~Field() {}
@@ -58,6 +59,16 @@ namespace locust
     void Field::SetCentralFrequency( double aCentralFrequency )
     {
     	fCentralFrequency = aCentralFrequency;
+    }
+
+    int Field::GetNPixels()
+    {
+    	return fnPixels;
+    }
+
+    void Field::SetNPixels( int aNumberOfPixels )
+    {
+    	fnPixels = aNumberOfPixels;
     }
 
 

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -55,6 +55,7 @@ namespace locust
 
             virtual double Integrate(int l, int m, int n, bool teMode, bool eField){return 0.;};
 
+            virtual double GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP) {return {0.};};
             std::vector<std::vector<std::vector<double>>> GetNormFactorsTE();
             void SetNormFactorsTE(std::vector<std::vector<std::vector<double>>> aNormFactor);
             std::vector<std::vector<std::vector<double>>> GetNormFactorsTM();

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -62,11 +62,15 @@ namespace locust
             void SetNormFactorsTM(std::vector<std::vector<std::vector<double>>> aNormFactor);
             double GetCentralFrequency();
             void SetCentralFrequency( double aCentralFrequency );
+            int GetNPixels();
+            void SetNPixels( int aNumberOfPixels );
 
         private:
             std::vector<std::vector<std::vector<double>>> fModeNormFactorTE;  // 3D vector [n-modes][n-modes][n-modes].
             std::vector<std::vector<std::vector<double>>> fModeNormFactorTM;  // 3D vector [n-modes][n-modes][n-modes].
             double fCentralFrequency;
+            int fnPixels;
+
 
     };
 

--- a/Source/Fields/LMCHFSSFieldMap.cc
+++ b/Source/Fields/LMCHFSSFieldMap.cc
@@ -27,13 +27,13 @@ namespace locust
 
     	std::vector<double> aField;
     	double xPozar, yPozar, xKass, yKass = 0.;
-    	double dX = fInterface->fX/fInterface->fnPixels;
-    	double dY = fInterface->fY/fInterface->fnPixels;
+    	double dX = fInterface->fX/GetNPixels();
+    	double dY = fInterface->fY/GetNPixels();
     	double tArea = 0.;
     	double tIntegral = 0.;
 
-    	for (unsigned i=0; i<fInterface->fnPixels; i++)
-    		for (unsigned j=0; j<fInterface->fnPixels; j++)
+    	for (unsigned i=0; i<GetNPixels(); i++)
+    		for (unsigned j=0; j<GetNPixels(); j++)
     		{
     	    	xPozar = (double)i*dX;
     	    	yPozar = (double)j*dY;

--- a/Source/Fields/LMCRectangularWaveguide.cc
+++ b/Source/Fields/LMCRectangularWaveguide.cc
@@ -116,7 +116,7 @@ namespace locust
     	double k = fcyc / LMCConst::C();
     	double beta = sqrt(k*k - kc*kc);
 
-    	double Z_TE = k*eta/beta;
+    	double Z_TE = k*eta/beta;  // This is 448 ohms for TE10 at 25.9 GHz.
     	return 2. * LMCConst::Pi() * Z_TE / LMCConst::C() / 1.e2; // Jackson Eq. 8.140, 1.e2 is m/s -> cm/s
     }
 

--- a/Source/Fields/LMCRectangularWaveguide.cc
+++ b/Source/Fields/LMCRectangularWaveguide.cc
@@ -75,6 +75,38 @@ namespace locust
     	return tIntegral;
     }
 
+
+    double RectangularWaveguide::GetGroupVelocity(int m, int n, double fcyc)
+    {
+    	double CutOffFrequency = 0.;
+    	if ((m<2)&&(n<1))  // most likely case
+    	{
+    		// rad/s
+    		CutOffFrequency = LMCConst::C() * LMCConst::Pi() / fInterface->fX;
+    	}
+    	else  // general case
+    	{
+    		// rad/s
+    		CutOffFrequency = LMCConst::C() *
+    				sqrt(pow(m*LMCConst::Pi()/fInterface->fX,2.) + sqrt(pow(n*LMCConst::Pi()/fInterface->fY,2.)));
+    	}
+        double GroupVelocity = LMCConst::C() * pow( 1. - pow(CutOffFrequency/fcyc, 2.) , 0.5);
+        //        printf("GroupVelocity is %g\n", GroupVelocity); getchar();
+        return GroupVelocity;
+    }
+
+
+    double RectangularWaveguide::GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP)
+    {
+    	double fcyc = tKassParticleXP[7];
+    	double groupVelocity = GetGroupVelocity(m,n,fcyc);
+    	double zVelocity = tKassParticleXP[5];
+        double gammaZ = 1.0 / pow(1.0-pow(zVelocity/groupVelocity,2.),0.5);
+        double fPrime = fcyc * gammaZ * (1.+zVelocity/groupVelocity);
+    	return fPrime;
+    }
+
+
     double RectangularWaveguide::Z_TE(int l, int m, int n, double fcyc) const
     {
     	double k1 = m * LMCConst::Pi() / fInterface->fX;

--- a/Source/Fields/LMCRectangularWaveguide.cc
+++ b/Source/Fields/LMCRectangularWaveguide.cc
@@ -23,13 +23,13 @@ namespace locust
 
     	std::vector<double> aField;
     	double xPozar, yPozar, xKass, yKass = 0.;
-    	double dX = fInterface->fX/fInterface->fnPixels;
-    	double dY = fInterface->fY/fInterface->fnPixels;
+    	double dX = fInterface->fX/GetNPixels();
+    	double dY = fInterface->fY/GetNPixels();
     	double tArea = 0.;
     	double tIntegral = 0.;
 
-    	for (unsigned i=0; i<fInterface->fnPixels; i++)
-    		for (unsigned j=0; j<fInterface->fnPixels; j++)
+    	for (unsigned i=0; i<GetNPixels(); i++)
+    		for (unsigned j=0; j<GetNPixels(); j++)
     		{
     	    	xPozar = (double)i*dX;
     	    	yPozar = (double)j*dY;

--- a/Source/Fields/LMCRectangularWaveguide.hh
+++ b/Source/Fields/LMCRectangularWaveguide.hh
@@ -44,9 +44,11 @@ namespace locust
             double Z_TE(int l, int m, int n, double fcyc) const;
             double Z_TM(int l, int m, int n, double fcyc) const;
             double Integrate(int l, int m, int n, bool teMode, bool eField);
+            double GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP);
 
 
         private:
+            double GetGroupVelocity(int m, int n, double fcyc);
             kl_interface_ptr_t fInterface;
 
 

--- a/Source/Generators/LMCCavitySignalGenerator.hh
+++ b/Source/Generators/LMCCavitySignalGenerator.hh
@@ -75,6 +75,7 @@ namespace locust
             bool ModeSelect(int l, int m, int n, bool eGun);
             void CheckNormalization();
             void PrintModeMaps();
+            double PoyntingVectorIntegral(double fcyc);
 
 
 

--- a/Source/Kassiopeia/LMCKassLocustInterface.cc
+++ b/Source/Kassiopeia/LMCKassLocustInterface.cc
@@ -42,7 +42,6 @@ namespace locust
 			fL( 0.2 ),
 			fX( 0.010668 ),
 			fY( 0.004318 ),
-			fnPixels( 100 ),
 	        nFilterBinsRequired( 0 ),
 	        dtFilter( 0 ),
 	        eCurrentBuffer( 0 ),

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -68,7 +68,6 @@ namespace locust
         double fL;
         double fX;  // Rectangular waveguide dimensions.
         double fY;
-        int fnPixels;
         int nFilterBinsRequired;
         double dtFilter;
         std::vector<std::deque<double>> eCurrentBuffer;

--- a/Source/RxComponents/LMCPowerCombiner.cc
+++ b/Source/RxComponents/LMCPowerCombiner.cc
@@ -30,7 +30,8 @@ namespace locust
             fCavityProbeTheta( 0. ),
 			fvoltageCheck( false ),
 			fRollingAvg( 0. ),
-			fCounter( 0 )
+			fCounter( 0 ),
+			fVoltagePhase( 0. )
 
     {}
     PowerCombiner::~PowerCombiner() {}
@@ -108,13 +109,14 @@ namespace locust
 	}
 
 
-	bool PowerCombiner::AddOneModeToCavityProbe(Signal* aSignal, double VoltageFIRSample, double phi_LO, double totalScalingFactor, double cavityProbeImpedance, unsigned sampleIndex)
+	bool PowerCombiner::AddOneModeToCavityProbe(Signal* aSignal, double excitationAmplitude, double dopplerFrequency, double dt, double phi_LO, double totalScalingFactor, double cavityProbeImpedance, unsigned sampleIndex)
 	{
 
-		aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2. * VoltageFIRSample * totalScalingFactor * cavityProbeImpedance * sin(phi_LO);
-		aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2. * VoltageFIRSample * totalScalingFactor * cavityProbeImpedance * cos(phi_LO);
+		fVoltagePhase += dopplerFrequency * dt;
+		double voltageValue = excitationAmplitude * cos(fVoltagePhase);
 
-//		printf("signal is %g\n", aSignal->LongSignalTimeComplex()[sampleIndex][0]); getchar();
+		aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2. * voltageValue * totalScalingFactor * cavityProbeImpedance * sin(phi_LO);
+		aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2. * voltageValue * totalScalingFactor * cavityProbeImpedance * cos(phi_LO);
 
 		if ( (fvoltageCheck==true) && (sampleIndex%100 < 1) )
 			LPROG( lmclog, "Voltage " << sampleIndex << " is <" << aSignal->LongSignalTimeComplex()[sampleIndex][1] << ">" );

--- a/Source/RxComponents/LMCPowerCombiner.hh
+++ b/Source/RxComponents/LMCPowerCombiner.hh
@@ -39,8 +39,8 @@ namespace locust
         	virtual bool SetSMatrixParameters() {return true;};
         	virtual bool IsSinglePatch();
             virtual Receiver* ChooseElement();
-        	bool AddOneVoltageToStripSum(Signal* aSignal, double VoltageFIRSample, double phi_LO, unsigned z_index, unsigned sampleIndex);
-        	bool AddOneModeToCavityProbe(Signal* aSignal, double VoltageFIRSample, double phi_LO, double totalScalingFactor, double cavityProbeImpedance, unsigned sampleIndex);
+        	bool AddOneVoltageToStripSum(Signal* aSignal, double excitationAmplitude, double phi_LO, unsigned z_index, unsigned sampleIndex);
+        	bool AddOneModeToCavityProbe(Signal* aSignal, double excitationAmplitude, double dopplerFrequency, double dt, double phi_LO, double totalScalingFactor, double cavityProbeImpedance, unsigned sampleIndex);
         	virtual void SayHello();
         	virtual void Initialize() {};
 
@@ -87,6 +87,7 @@ namespace locust
             std::vector<double> fCavityProbeTheta;
             std::vector<std::vector<std::vector<double>>> fRollingAvg;
             std::vector<std::vector<std::vector<int>>> fCounter;
+            double fVoltagePhase;
 
 
 };

--- a/Source/Transmitters/LMCKassCurrentTransmitter.cc
+++ b/Source/Transmitters/LMCKassCurrentTransmitter.cc
@@ -121,6 +121,7 @@ namespace locust
         particleXP[5] = tvZ;
         particleXP[6] = calcOrbitPhase(tvX, tvY);
         particleXP[7] = tParticle.GetCyclotronFrequency();
+        particleXP[8] = tParticle.GetLarmorPower();
 
     	return particleXP;
     }


### PR DESCRIPTION
These changes support Kass->Locust->Katydid ~fW signal generation in the e-gun waveguide using an analytic impedance at 25.9 GHz.  The next step will be to swap in a more realistic HFSS complex frequency-dependent impedance.

The merge is being requested now for alignment with work toward similar normalization using HFSS and in the cavity effort.