### PR TITLE
Feature/unit tests

### DIFF
--- a/Source/Applications/Testing/CMakeLists.txt
+++ b/Source/Applications/Testing/CMakeLists.txt
@@ -11,6 +11,7 @@
         testMockFreeField.cc
         testLMCTestSignal.cc
         testLMCPlaneWaveFIR.cc
+        testLMCCavity.cc        
     )
      
     set( lib_dependencies 
@@ -37,5 +38,8 @@
         
     add_executable( testLMCPlaneWaveFIR testLMCPlaneWaveFIR.cc testCatch.cc)
     target_link_libraries( testLMCPlaneWaveFIR ${lib_dependencies})
-
+    
+    add_executable( testLMCCavity testLMCCavity.cc testCatch.cc)
+    target_link_libraries( testLMCCavity ${lib_dependencies})
+    
     

--- a/Source/Applications/Testing/CMakeLists.txt
+++ b/Source/Applications/Testing/CMakeLists.txt
@@ -1,4 +1,4 @@
-    set( CPP_DIR Cpp )
+#    set( CPP_DIR Cpp )
     
     include_directories( BEFORE 
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13,12 +13,18 @@
         testLMCPlaneWaveFIR.cc
         testLMCCavity.cc        
     )
+
+#    set( testing_HEADERS
+#        LMCTestParameterHandler.hh
+#    ) 
      
     set( lib_dependencies 
         LocustMC
     )     
      
     add_library( Catch INTERFACE )
+#    pbuilder_install_headers( ${testing_HEADERS} )
+    
     target_include_directories( Catch INTERFACE ${Scarab_LOCATION}/testing/catch )
 
     add_executable( RunTests ${testing_SOURCES} )

--- a/Source/Applications/Testing/LMCTestParameterHandler.hh
+++ b/Source/Applications/Testing/LMCTestParameterHandler.hh
@@ -1,0 +1,50 @@
+/*
+ * LMCTestParameterHandler.hh
+ *
+ *  Created on: Dec 7, 2022
+ *      Author: pslocum
+ */
+
+#ifndef LMCTESTPARAMETERHANDLER_HH_
+#define LMCTESTPARAMETERHANDLER_HH_
+
+#include <iostream>
+using namespace std;
+
+ /*!
+ @class TestParameterHandler
+ @author P. Slocum
+ @brief Class to configure Catch2 test cases.
+ @details
+ Available configuration options:
+ No input parameters
+ */
+
+class TestParameterHandler
+{
+
+    public:
+	    static TestParameterHandler* getInstance();
+	    void SetParameters(double aValue) {testVar = aValue;};
+	    double GetParameters() {return(testVar);};
+	    void SetArgs(int anArgc, char** anArgv) {argc = anArgc; argv = anArgv;};
+	    int GetArgc() {return(argc);};
+	    char** GetArgv() {return(argv);};
+
+
+
+    private:
+       static TestParameterHandler* inst_;   // The one, single instance
+       TestParameterHandler() : testVar(0), argc(0), argv(0) {} // private constructor
+       TestParameterHandler(const TestParameterHandler&);
+       TestParameterHandler& operator=(const TestParameterHandler&);
+
+       double testVar;
+       int argc;
+       char** argv;
+};
+
+
+
+
+#endif /* LMCTESTPARAMETERHANDLER_HH_ */

--- a/Source/Applications/Testing/testCatch.cc
+++ b/Source/Applications/Testing/testCatch.cc
@@ -1,9 +1,45 @@
 // testCatch.cc
 
 // Let Catch provide main():
-#define CATCH_CONFIG_MAIN
+//#define CATCH_CONFIG_MAIN
 
+#define CATCH_CONFIG_RUNNER
+
+#include "application.hh"
+#include "logger.hh"
 #include "catch.hpp"
+
+
+
+using namespace scarab;
+
+class test_app : public main_app
+{
+    public:
+        test_app() :
+            main_app(),
+			fAdjustedIncidentPower(0.)
+        {
+            add_option("-i,--incident-power", fAdjustedIncidentPower, "Set the power incident at the antenna (Watts)" );
+        }
+
+        virtual ~test_app() {}
+
+    private:
+        double fAdjustedIncidentPower;
+};
+
+int main(int argc, char *argv[])
+{
+
+	test_app the_main;
+	CLI11_PARSE( the_main, argc, argv );
+
+	Catch::Session session; // There must be exactly one instance
+
+	return session.run();
+}
+
 
 int Factorial( int number ) {
    return number <= 1 ? number : Factorial( number - 1 ) * number;  // fail
@@ -21,6 +57,7 @@ TEST_CASE( "Factorials of 1 and higher are computed (pass)", "[single-file]" ) {
     REQUIRE( Factorial(3) == 6 );
     REQUIRE( Factorial(10) == 3628800 );
 }
+
 
 // Compile & run:
 // - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 010-TestCase 010-TestCase.cpp && 010-TestCase --success

--- a/Source/Applications/Testing/testCatch.cc
+++ b/Source/Applications/Testing/testCatch.cc
@@ -8,32 +8,27 @@
 #include "application.hh"
 #include "logger.hh"
 #include "catch.hpp"
+#include "LMCTestParameterHandler.hh"
 
 
+// Define the static Singleton pointer
+TestParameterHandler* TestParameterHandler::inst_ = NULL;
 
-using namespace scarab;
-
-class test_app : public main_app
+TestParameterHandler* TestParameterHandler::getInstance()
 {
-    public:
-        test_app() :
-            main_app(),
-			fAdjustedIncidentPower(0.)
-        {
-            add_option("-i,--incident-power", fAdjustedIncidentPower, "Set the power incident at the antenna (Watts)" );
-        }
+    if (inst_ == NULL)
+    {
+    	inst_ = new TestParameterHandler();
+    }
+   return(inst_);
+}
 
-        virtual ~test_app() {}
 
-    private:
-        double fAdjustedIncidentPower;
-};
 
 int main(int argc, char *argv[])
 {
-
-	test_app the_main;
-	CLI11_PARSE( the_main, argc, argv );
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+	p1->SetArgs(argc, argv);
 
 	Catch::Session session; // There must be exactly one instance
 

--- a/Source/Applications/Testing/testFFT.cc
+++ b/Source/Applications/Testing/testFFT.cc
@@ -7,6 +7,8 @@
 #include <fftw3.h>
 #include <math.h>
 #include "catch.hpp"
+#include "LMCTestParameterHandler.hh"
+
 
 using namespace scarab;
 
@@ -16,14 +18,16 @@ class test_app : public main_app
 {
     public:
         test_app() :
-            main_app()
+            main_app(),
+			fTestParameter(0.)
         {
+            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
         }
 
         virtual ~test_app() {}
 
     private:
-
+        double fTestParameter;
 };
 
 
@@ -76,10 +80,19 @@ double GetPower(bool bTime)
 
 }
 
+int parseFFT()
+{
+	test_app the_main;
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+    CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
+	return 0;
+}
+
 
 
 TEST_CASE( "Power before FFT = power after FFT (pass)", "[single-file]" )
 {
+	parseFFT();
 	double threshold = 1.e-4;
     REQUIRE( fabs(GetPower(1)-GetPower(0)) < threshold );
 }

--- a/Source/Applications/Testing/testFFT.cc
+++ b/Source/Applications/Testing/testFFT.cc
@@ -21,10 +21,16 @@ class test_app : public main_app
             main_app(),
 			fTestParameter(0.)
         {
-            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+            add_option("-t,--test-parameter", fTestParameter, "Set a test parameter." );
         }
 
         virtual ~test_app() {}
+
+        double GetTestParameter()
+        {
+            return fTestParameter;
+        }
+
 
     private:
         double fTestParameter;
@@ -80,9 +86,8 @@ double GetPower(bool bTime)
 
 }
 
-int parseFFT()
+int parseFFT(test_app& the_main)
 {
-	test_app the_main;
 	TestParameterHandler* p1 = TestParameterHandler::getInstance();
     CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
 	return 0;
@@ -92,7 +97,8 @@ int parseFFT()
 
 TEST_CASE( "Power before FFT = power after FFT (pass)", "[single-file]" )
 {
-	parseFFT();
+	test_app the_main;
+	parseFFT(the_main);
 	double threshold = 1.e-4;
     REQUIRE( fabs(GetPower(1)-GetPower(0)) < threshold );
 }

--- a/Source/Applications/Testing/testLMCCavity.cc
+++ b/Source/Applications/Testing/testLMCCavity.cc
@@ -23,10 +23,15 @@ class test_app : public main_app
             main_app(),
 			fTestParameter(0.)
         {
-            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+            add_option("-t,--test-parameter", fTestParameter, "Set a test parameter." );
         }
 
         virtual ~test_app() {}
+
+        double GetTestParameter()
+        {
+        	return fTestParameter;
+        }
 
     private:
         double fTestParameter;
@@ -138,9 +143,8 @@ public:
 };
 
 
-int parseCavity()
+int parseCavity(test_app& the_main)
 {
-	test_app the_main;
 	TestParameterHandler* p1 = TestParameterHandler::getInstance();
     CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
 	return 0;
@@ -149,7 +153,9 @@ int parseCavity()
 
 TEST_CASE( "testLMCCavity with default parameter values (pass)", "[single-file]" )
 {
-	parseCavity();
+	test_app the_main;
+	parseCavity(the_main);
+	LPROG( testlog, "fTestParameter is " << the_main.GetTestParameter() );
 
 	testLMCCavity aTestLMCCavity;
 	if (!aTestLMCCavity.Configure())

--- a/Source/Applications/Testing/testLMCCavity.cc
+++ b/Source/Applications/Testing/testLMCCavity.cc
@@ -9,11 +9,29 @@
 #include <fftw3.h>
 #include <math.h>
 #include "catch.hpp"
+#include "LMCTestParameterHandler.hh"
 
 using namespace scarab;
 using namespace locust;
 
 LOGGER( testlog, "testLMCCavity" );
+
+class test_app : public main_app
+{
+    public:
+        test_app() :
+            main_app(),
+			fTestParameter(0.)
+        {
+            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+        }
+
+        virtual ~test_app() {}
+
+    private:
+        double fTestParameter;
+};
+
 
 class testLMCCavity
 {
@@ -120,9 +138,19 @@ public:
 };
 
 
+int parseCavity()
+{
+	test_app the_main;
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+    CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
+	return 0;
+}
+
 
 TEST_CASE( "testLMCCavity with default parameter values (pass)", "[single-file]" )
 {
+	parseCavity();
+
 	testLMCCavity aTestLMCCavity;
 	if (!aTestLMCCavity.Configure())
 	{

--- a/Source/Applications/Testing/testLMCCavity.cc
+++ b/Source/Applications/Testing/testLMCCavity.cc
@@ -1,0 +1,166 @@
+#include "LMCSignal.hh"
+#include "LMCTFFileHandler.hh"
+#include "LMCFIRFileHandler.hh"
+#include "LMCAnalyticResponseFunction.hh"
+#include "LMCDampedHarmonicOscillator.hh"
+#include "application.hh"
+#include "logger.hh"
+#include "LMCConst.hh"
+#include <fftw3.h>
+#include <math.h>
+#include "catch.hpp"
+
+using namespace scarab;
+using namespace locust;
+
+LOGGER( testlog, "testLMCCavity" );
+
+class testLMCCavity
+{
+public:
+
+	testLMCCavity():
+        fRF_frequency(0.),
+        fLO_frequency(0.),
+        fAmplitude(0.),
+        fAcquisitionRate(0.),
+		fFilterRate(0.),
+		fPhaseLagLO(0.),
+		fTFReceiverHandler( 0 ),
+		fAnalyticResponseFunction( 0 )
+    {
+    }
+
+	const scarab::param_node* GetParams()
+	{
+	    scarab::param_node* param_0( new param_node() );
+	    std::string tDataDir = TOSTRING(PB_DATA_INSTALL_DIR);
+	    std::string filepath = tDataDir + "/PatchTFLocust.txt";
+	    param_0->add( "tf-receiver-filename", filepath.c_str() );
+	    param_0->add( "tf-receiver-bin-width", 0.01e9 );
+	    return param_0;
+	}
+
+	bool Configure()
+	{
+		fTFReceiverHandler = new TFReceiverHandler();
+		if ( !fTFReceiverHandler->Configure(*GetParams()) )
+		{
+			LWARN(testlog,"TFReceiverHandler was not configured correctly.");
+		    return false;
+		}
+
+		fAnalyticResponseFunction = new DampedHarmonicOscillator();
+		if ( !fAnalyticResponseFunction->Configure(*GetParams()) )
+		{
+			LWARN(testlog,"DampedHarmonicOscillator was not configured.");
+			return false;
+		}
+		if ( !fTFReceiverHandler->ConvertAnalyticGFtoFIR(fAnalyticResponseFunction->GetGFarray()) )
+		{
+			LWARN(testlog,"GF->FIR was not generated.");
+			return false;
+		}
+
+        fRF_frequency = 0.9e9; // Hz
+        fLO_frequency = 0.05e9; // Hz
+        fAcquisitionRate = 201.e6; // Hz
+        fAmplitude = 5.e-6; // volts
+        fPhaseLagLO = 0.;
+		return true;
+	}
+
+
+
+	bool PopulateSignal(Signal* aSignal, int N0, double timeStamp)
+	{
+
+        double LO_phase = 0.;
+        double voltage_phase = 0.;
+        double phaseLagRF = 2.*LMCConst::Pi() * timeStamp/(1./fRF_frequency);
+        fPhaseLagLO += 2.*LMCConst::Pi() * fLO_frequency * 1./fAcquisitionRate;
+
+        for( unsigned index = 0; index < N0; ++index )
+        {
+            LO_phase = fPhaseLagLO;
+            voltage_phase = phaseLagRF + 2.*LMCConst::Pi()*fRF_frequency*(double)index/fFilterRate;
+
+            // keep only lower sideband RF-LO
+            aSignal->LongSignalTimeComplex()[index][0] = fAmplitude*cos(voltage_phase-LO_phase);
+            aSignal->LongSignalTimeComplex()[index][1] = fAmplitude*cos(-LMCConst::Pi()/2. + voltage_phase-LO_phase);
+        }
+//        printf("fAmplitude is %g, signal[0][0] is %g with phaseLagRF %g and LOPhase %g at time stamp %g\n", fAmplitude, aSignal->LongSignalTimeComplex()[0][0], phaseLagRF, fPhaseLagLO, timeStamp);
+//        getchar();
+        return true;
+	}
+
+	std::deque<double> SignalToDeque(Signal* aSignal)
+	{
+	    std::deque<double> incidentSignal;
+	    for (unsigned i=0; i<fTFReceiverHandler->GetFilterSize(); i++)
+	    {
+	    	incidentSignal.push_back(aSignal->LongSignalTimeComplex()[i][0]);
+	    }
+	    return incidentSignal;
+	}
+
+
+    TFReceiverHandler* fTFReceiverHandler;
+    AnalyticResponseFunction* fAnalyticResponseFunction;
+
+    double fRF_frequency;
+    double fLO_frequency;
+    double fAcquisitionRate;
+    double fFilterRate;
+    double fAmplitude;
+    double fPhaseLagLO;
+
+
+
+};
+
+
+
+TEST_CASE( "testLMCCavity with default parameter values (pass)", "[single-file]" )
+{
+	testLMCCavity aTestLMCCavity;
+	if (!aTestLMCCavity.Configure())
+	{
+		LWARN(testlog,"testLMCCavity was not configured correctly.");
+	    REQUIRE( 0 > 1 );
+	}
+
+    /* initialize time series */
+    Signal* aSignal = new Signal();
+    int N0 = aTestLMCCavity.fTFReceiverHandler->GetFilterSize();
+    aTestLMCCavity.fFilterRate = (1./aTestLMCCavity.fTFReceiverHandler->GetFilterResolution());
+    aSignal->Initialize( N0 , 1 );
+
+    double firGainMax = 0.;
+
+        for (unsigned rfStep=0; rfStep<30; rfStep++) // frequency sweep
+        {
+            aTestLMCCavity.fRF_frequency = 1.0e9 + 0.005e9*rfStep;
+
+	        double convolutionMag = 0.;
+            for (unsigned i=0; i<1000; i++)  // time stamps
+            {
+                // populate time series and convolve it with the FIR filter
+        	    double timeStamp = i/aTestLMCCavity.fAcquisitionRate;
+                aTestLMCCavity.PopulateSignal(aSignal, N0, timeStamp);
+            	std::pair<double,double> convolutionPair = aTestLMCCavity.fTFReceiverHandler->ConvolveWithComplexFIRFilter(aTestLMCCavity.SignalToDeque(aSignal));
+                if (fabs(convolutionPair.first) > convolutionMag)
+                {
+        	        convolutionMag = convolutionPair.first;
+                }
+            } // i
+            double firGain = convolutionMag;
+			LPROG( testlog, "Cavity GF gain at frequency " << aTestLMCCavity.fRF_frequency << " is " << firGain );
+        } // rfStep
+
+    delete aSignal;
+
+    REQUIRE( 1 > 0. ); // to-do:  get this defined.
+}
+
+

--- a/Source/Applications/Testing/testLMCPlaneWaveFIR.cc
+++ b/Source/Applications/Testing/testLMCPlaneWaveFIR.cc
@@ -7,11 +7,30 @@
 #include <fftw3.h>
 #include <math.h>
 #include "catch.hpp"
+#include "LMCTestParameterHandler.hh"
+
 
 using namespace scarab;
 using namespace locust;
 
 LOGGER( testlog, "testLMCPlaneWaveFIR" );
+
+class test_app : public main_app
+{
+    public:
+        test_app() :
+            main_app(),
+			fTestParameter(0.)
+        {
+            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+        }
+
+        virtual ~test_app() {}
+
+    private:
+        double fTestParameter;
+};
+
 
 class testLMCPlaneWaveFIR
 {
@@ -107,10 +126,19 @@ public:
 
 };
 
+int parsePlaneWaveFIR()
+{
+	test_app the_main;
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+    CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
+	return 0;
+}
+
 
 
 TEST_CASE( "LMCPlaneWaveFIR with default parameter values (pass)", "[single-file]" )
 {
+	parsePlaneWaveFIR();
 	testLMCPlaneWaveFIR aTestLMCPlaneWaveFIR;
 	if ( !aTestLMCPlaneWaveFIR.Configure() )
 	{

--- a/Source/Applications/Testing/testLMCPlaneWaveFIR.cc
+++ b/Source/Applications/Testing/testLMCPlaneWaveFIR.cc
@@ -41,6 +41,17 @@ public:
 	bool Configure()
 	{
 		fTFReceiverHandler = new TFReceiverHandler();
+		if ( !fTFReceiverHandler->Configure(*GetParams()) )
+		{
+			LWARN(testlog,"TFReceiverHandler was not configured correctly.");
+		    return false;
+		}
+		if ( !fTFReceiverHandler->ReadHFSSFile() )
+	    {
+			LWARN(testlog,"TF file was not read correctly.");
+			return false;
+	    }
+
         fRF_frequency = 25.9e9; // Hz
         fLO_frequency = 25.85e9; // Hz
         fAcquisitionRate = 201.e6; // Hz
@@ -101,17 +112,11 @@ public:
 TEST_CASE( "LMCPlaneWaveFIR with default parameter values (pass)", "[single-file]" )
 {
 	testLMCPlaneWaveFIR aTestLMCPlaneWaveFIR;
-	aTestLMCPlaneWaveFIR.Configure();
-	aTestLMCPlaneWaveFIR.fTFReceiverHandler->Configure(*aTestLMCPlaneWaveFIR.GetParams());
-
-	if(!aTestLMCPlaneWaveFIR.fTFReceiverHandler->ReadHFSSFile())
-    {
-		REQUIRE( 0 == 1); // fail file read test
-    }
-	else
-    {
-		REQUIRE( 0 == 0); // pass file read test
-    }
+	if ( !aTestLMCPlaneWaveFIR.Configure() )
+	{
+		LWARN(testlog,"testLMCPlaneWaveFIR was not configured correctly.");
+	    REQUIRE( 0 > 1 );
+	}
 
     /* initialize time series */
     Signal* aSignal = new Signal();
@@ -141,7 +146,8 @@ TEST_CASE( "LMCPlaneWaveFIR with default parameter values (pass)", "[single-file
             // https://www.antenna-theory.com/definitions/antennafactor.php
             double firGain = 10.*log10(pow(1./(aTestLMCPlaneWaveFIR.fAmplitude/convolutionMag/9.73*(3.e8/aTestLMCPlaneWaveFIR.fRF_frequency)),2.));
             if (firGain > firGainMax) firGainMax = firGain;
-            printf("firGain at frequency %g is %g dB\n", aTestLMCPlaneWaveFIR.fRF_frequency, firGain);
+			LPROG( testlog, "FIR gain at frequency " << aTestLMCPlaneWaveFIR.fRF_frequency << " is " << firGain << " dB" );
+//            printf("firGain at frequency %g is %g dB\n", aTestLMCPlaneWaveFIR.fRF_frequency, firGain);
         } // rfStep
     }
 

--- a/Source/Applications/Testing/testLMCPlaneWaveFIR.cc
+++ b/Source/Applications/Testing/testLMCPlaneWaveFIR.cc
@@ -22,10 +22,16 @@ class test_app : public main_app
             main_app(),
 			fTestParameter(0.)
         {
-            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+            add_option("-t,--test-parameter", fTestParameter, "Set a test parameter." );
         }
 
         virtual ~test_app() {}
+
+        double GetTestParameter()
+        {
+            return fTestParameter;
+        }
+
 
     private:
         double fTestParameter;
@@ -126,9 +132,8 @@ public:
 
 };
 
-int parsePlaneWaveFIR()
+int parsePlaneWaveFIR(test_app& the_main)
 {
-	test_app the_main;
 	TestParameterHandler* p1 = TestParameterHandler::getInstance();
     CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
 	return 0;
@@ -138,7 +143,9 @@ int parsePlaneWaveFIR()
 
 TEST_CASE( "LMCPlaneWaveFIR with default parameter values (pass)", "[single-file]" )
 {
-	parsePlaneWaveFIR();
+	test_app the_main;
+	parsePlaneWaveFIR(the_main);
+
 	testLMCPlaneWaveFIR aTestLMCPlaneWaveFIR;
 	if ( !aTestLMCPlaneWaveFIR.Configure() )
 	{

--- a/Source/Applications/Testing/testLMCTestSignal.cc
+++ b/Source/Applications/Testing/testLMCTestSignal.cc
@@ -5,11 +5,29 @@
 #include <fftw3.h>
 #include <math.h>
 #include "catch.hpp"
+#include "LMCTestParameterHandler.hh"
+
 
 using namespace scarab;
 using namespace locust;
 
 LOGGER( testlog, "testLMCTestSignal" );
+
+class test_app : public main_app
+{
+    public:
+        test_app() :
+            main_app(),
+			fTestParameter(0.)
+        {
+            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+        }
+
+        virtual ~test_app() {}
+
+    private:
+        double fTestParameter;
+};
 
 
 class testLMCTestSignal
@@ -115,9 +133,21 @@ public:
 
 };
 
+int parseTestSignal()
+{
+	test_app the_main;
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+    CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
+	return 0;
+}
+
+
+
+
 
 TEST_CASE( "LMCTestSignal with default parameter values (pass)", "[single-file]" )
 {
+	parseTestSignal();
 	testLMCTestSignal aTestLMCTestSignal;
     Signal* aSignal = new Signal();
     int N0 = 1000;

--- a/Source/Applications/Testing/testLMCTestSignal.cc
+++ b/Source/Applications/Testing/testLMCTestSignal.cc
@@ -20,10 +20,16 @@ class test_app : public main_app
             main_app(),
 			fTestParameter(0.)
         {
-            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+            add_option("-t,--test-parameter", fTestParameter, "Set a test parameter.");
         }
 
         virtual ~test_app() {}
+
+        double GetTestParameter()
+        {
+            return fTestParameter;
+        }
+
 
     private:
         double fTestParameter;

--- a/Source/Applications/Testing/testMockEGun.cc
+++ b/Source/Applications/Testing/testMockEGun.cc
@@ -30,10 +30,28 @@
 #include <fftw3.h>
 #include <math.h>
 #include "catch.hpp"
+#include "LMCTestParameterHandler.hh"
+
 
 using namespace scarab;
 
 LOGGER( testlog, "testMockEGun" );
+
+class test_app : public main_app
+{
+    public:
+        test_app() :
+            main_app(),
+			fTestParameter(0.)
+        {
+            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+        }
+
+        virtual ~test_app() {}
+
+    private:
+        double fTestParameter;
+};
 
 
 double GetPower()
@@ -86,9 +104,18 @@ double GetPower()
 
 }
 
+int parseEGun()
+{
+	test_app the_main;
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+    CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
+	return 0;
+}
+
 
 TEST_CASE( "Larmor power fraction. (pass)", "[single-file]" )
 {
+	parseEGun();
 	double expectedPower = 2.e-16;
 	double threshold = 1.e-4;
     REQUIRE( fabs(GetPower() - expectedPower) <= threshold*expectedPower );

--- a/Source/Applications/Testing/testMockEGun.cc
+++ b/Source/Applications/Testing/testMockEGun.cc
@@ -44,10 +44,15 @@ class test_app : public main_app
             main_app(),
 			fTestParameter(0.)
         {
-            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+            add_option("-t,--test-parameter", fTestParameter, "Set a test parameter." );
         }
 
         virtual ~test_app() {}
+
+        double GetTestParameter()
+        {
+        	return fTestParameter;
+        }
 
     private:
         double fTestParameter;
@@ -104,9 +109,8 @@ double GetPower()
 
 }
 
-int parseEGun()
+int parseEGun(test_app& the_main)
 {
-	test_app the_main;
 	TestParameterHandler* p1 = TestParameterHandler::getInstance();
     CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
 	return 0;
@@ -115,7 +119,8 @@ int parseEGun()
 
 TEST_CASE( "Larmor power fraction. (pass)", "[single-file]" )
 {
-	parseEGun();
+	test_app the_main;
+	parseEGun(the_main);
 	double expectedPower = 2.e-16;
 	double threshold = 1.e-4;
     REQUIRE( fabs(GetPower() - expectedPower) <= threshold*expectedPower );

--- a/Source/Applications/Testing/testMockFreeField.cc
+++ b/Source/Applications/Testing/testMockFreeField.cc
@@ -28,10 +28,28 @@
 #include <math.h>
 #include "catch.hpp"
 #include "LMCConst.hh"
+#include "LMCTestParameterHandler.hh"
+
 
 using namespace scarab;
 
 LOGGER( testlog, "testMockFreeField" );
+
+class test_app : public main_app
+{
+    public:
+        test_app() :
+            main_app(),
+			fTestParameter(0.)
+        {
+            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+        }
+
+        virtual ~test_app() {}
+
+    private:
+        double fTestParameter;
+};
 
 
 class PowerHandler
@@ -43,10 +61,6 @@ class PowerHandler
         fRadius( 0.1 ), // m
         fEffectiveAperture( 1.e-5 ) // m^2.
     {
-    	// TO-DO:  Parameter acceptance and usage is not working here.
-    	// That might not be important for unit tests, which are typically automated.
-    	// test_app the_main;
-    	// CLI11_PARSE( the_main, argc, argv );
     }
 
         void SetLarmorPower( double aPower ) { fLarmorPower = aPower; }
@@ -67,12 +81,20 @@ class PowerHandler
 
 };
 
+int parseFreeField()
+{
+	test_app the_main;
+	TestParameterHandler* p1 = TestParameterHandler::getInstance();
+    CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
+	return 0;
+}
 
 
 
 TEST_CASE( "Mock free space Larmor power. (pass)", "[single-file]" )
 {
 
+	parseFreeField();
 	PowerHandler aPowerHandler;
 
 	double radius = aPowerHandler.GetRadius(); // meters

--- a/Source/Applications/Testing/testMockFreeField.cc
+++ b/Source/Applications/Testing/testMockFreeField.cc
@@ -42,10 +42,15 @@ class test_app : public main_app
             main_app(),
 			fTestParameter(0.)
         {
-            add_option("-i,--incident-power", fTestParameter, "Set a test parameter." );
+            add_option("-t,--test-parameter", fTestParameter, "Set a test parameter." );
         }
 
         virtual ~test_app() {}
+
+        double GetTestParameter()
+        {
+            return fTestParameter;
+        }
 
     private:
         double fTestParameter;
@@ -81,9 +86,8 @@ class PowerHandler
 
 };
 
-int parseFreeField()
+int parseFreeField(test_app& the_main)
 {
-	test_app the_main;
 	TestParameterHandler* p1 = TestParameterHandler::getInstance();
     CLI11_PARSE( the_main, p1->GetArgc(), p1->GetArgv() );
 	return 0;
@@ -93,8 +97,8 @@ int parseFreeField()
 
 TEST_CASE( "Mock free space Larmor power. (pass)", "[single-file]" )
 {
-
-	parseFreeField();
+	test_app the_main;
+	parseFreeField(the_main);
 	PowerHandler aPowerHandler;
 
 	double radius = aPowerHandler.GetRadius(); // meters

--- a/Source/Applications/Testing/testMockFreeField.cc
+++ b/Source/Applications/Testing/testMockFreeField.cc
@@ -34,26 +34,6 @@ using namespace scarab;
 LOGGER( testlog, "testMockFreeField" );
 
 
-
-class test_app : public main_app
-{
-    public:
-        test_app() :
-            main_app(),
-			fAdjustedIncidentPower(0.)
-        {
-            add_option("-i,--incident-power", fAdjustedIncidentPower, "Set the power incident at the antenna (Watts)" );
-        }
-
-        virtual ~test_app() {}
-
-    private:
-        double fAdjustedIncidentPower;
-
-
-};
-
-
 class PowerHandler
 {
     public:
@@ -89,10 +69,11 @@ class PowerHandler
 
 
 
+
 TEST_CASE( "Mock free space Larmor power. (pass)", "[single-file]" )
 {
 
-    PowerHandler aPowerHandler;
+	PowerHandler aPowerHandler;
 
 	double radius = aPowerHandler.GetRadius(); // meters
 	double PoyntingVector = aPowerHandler.GetLarmorPower() / (4.*locust::LMCConst::Pi()*radius*radius);


### PR DESCRIPTION
Some additional functionality has been added to the existing unit tests.  Command-line parameter handling is now supported in each test case using scarab libraries, as in the below example.

```
./testLMCCavity -h
Usage: ./testLMCCavity [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -c,--config FILE            Config file filename
  --verbosity UINT            Global logger verosity
  -V,--version                Print the version message and exit
  -t,--test-parameter FLOAT   Set a test parameter.

```