### PR TITLE
Revert to Kass v3.7.7 and build without VTK while completing upgrade …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if (locust_mc_BUILD_WITH_KASSIOPEIA)
                       -D BUILD_KEMFIELD:BOOL=TRUE 
                       -D BUILD_KGEOBAG:BOOL=TRUE 
                       -D BUILD_KOMMON:BOOL=TRUE 
-                      -D KASPER_USE_VTK:BOOL=TRUE
+                      -D KASPER_USE_VTK:BOOL=FALSE
                       ${PROJECT_SOURCE_DIR}/kassiopeia
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/kassiopeia
     )
@@ -66,7 +66,7 @@ if (locust_mc_BUILD_WITH_KASSIOPEIA)
                       -D BUILD_KEMFIELD:BOOL=TRUE 
                       -D BUILD_KGEOBAG:BOOL=TRUE 
                       -D BUILD_KOMMON:BOOL=TRUE 
-                      -D KASPER_USE_VTK:BOOL=TRUE
+                      -D KASPER_USE_VTK:BOOL=FALSE
                       ${PROJECT_SOURCE_DIR}/kassiopeia
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/kassiopeia
     )


### PR DESCRIPTION
…to v3.8.2 .