### PR TITLE
Install unit tests to project binary directory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             --build-arg locust_tag=${locust_mc_TAG} \
             --tag project8/locust_mc:${locust_mc_TAG} \
             .  
-          docker run project8/locust_mc:${locust_mc_TAG} /usr/local/p8/locust/v2.2.0/RunTests
+          docker run project8/locust_mc:${locust_mc_TAG} /usr/local/p8/locust/v2.2.0/bin/RunTests
 
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             --build-arg locust_tag=${locust_mc_TAG} \
             --tag project8/locust_mc:${locust_mc_TAG} \
             .  
-          docker run project8/locust_mc:${locust_mc_TAG} /tmp_source/build/Source/Applications/Testing/RunTests
+          docker run project8/locust_mc:${locust_mc_TAG} /usr/local/p8/locust/v2.2.0/RunTests
 
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             --build-arg locust_tag=${locust_mc_TAG} \
             --tag project8/locust_mc:${locust_mc_TAG} \
             .  
-          docker run project8/locust_mc:${locust_mc_TAG} /usr/local/p8/locust/v2.2.0/bin/RunTests
+          docker run project8/locust_mc:${locust_mc_TAG} /tmp_source/build/Source/Applications/Testing/RunTests
 
 
 

--- a/Source/Applications/CMakeLists.txt
+++ b/Source/Applications/CMakeLists.txt
@@ -1,5 +1,3 @@
-if( locust_mc_ENABLE_EXECUTABLES )
-
     set( lib_dependencies 
         LocustMC
     )
@@ -14,8 +12,9 @@ if( locust_mc_ENABLE_EXECUTABLES )
         )
     endif( locust_mc_BUILD_WITH_KASSIOPEIA )
     
-    pbuilder_executables( programs lib_dependencies )
-
-endif( locust_mc_ENABLE_EXECUTABLES )
-
-add_subdirectory( Testing )
+    pbuilder_executables( programs lib_dependencies )    
+    
+    if (locust_mc_ENABLE_TESTING)
+        add_subdirectory( Testing )    
+    endif (locust_mc_ENABLE_TESTING)
+    

--- a/Source/Applications/Testing/CMakeLists.txt
+++ b/Source/Applications/Testing/CMakeLists.txt
@@ -1,7 +1,5 @@
-#    set( CPP_DIR Cpp )
-    
     include_directories( BEFORE 
-    ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
     )    
 
     set( testing_SOURCES
@@ -13,17 +11,12 @@
         testLMCPlaneWaveFIR.cc
         testLMCCavity.cc        
     )
-
-#    set( testing_HEADERS
-#        LMCTestParameterHandler.hh
-#    ) 
      
     set( lib_dependencies 
         LocustMC
     )     
      
     add_library( Catch INTERFACE )
-#    pbuilder_install_headers( ${testing_HEADERS} )
     
     target_include_directories( Catch INTERFACE ${Scarab_LOCATION}/testing/catch )
 
@@ -46,6 +39,13 @@
     target_link_libraries( testLMCPlaneWaveFIR ${lib_dependencies})
     
     add_executable( testLMCCavity testLMCCavity.cc testCatch.cc)
-    target_link_libraries( testLMCCavity ${lib_dependencies})
+    target_link_libraries( testLMCCavity ${lib_dependencies})    
+            
+    set( programs
+        RunTests
+    )    
+       
+    pbuilder_executables( programs lib_dependencies )
+    install( TARGETS RunTests testFFT testMockEGun testMockFreeField testLMCTestSignal testLMCPlaneWaveFIR testLMCCavity DESTINATION ${PROJECT_BINARY_DIRECTORY} )
     
     


### PR DESCRIPTION
With minor changes in CMakeLists.txt files, the unit tests are now being installed instead of just being built.  This should allow better access from inside docker containers.