### PR TITLE
Feature/patch configs

### DIFF
--- a/Config/LocustCavity1GHz.json.in
+++ b/Config/LocustCavity1GHz.json.in
@@ -14,7 +14,7 @@
         "cavity-length": 3.0,           
         "back-reaction": "true",
         "dho-cavity-frequency": 1.067e9,
-        "dho-time-resolution": 1.0e-8,
+        "dho-time-resolution": 1.0e-9,
         "dho-threshold-factor": 0.01,
         "event-spacing-samples": 10,
         "e-gun": false,        
@@ -40,8 +40,8 @@
 
     "digitizer":
     {
-        "v-range":  4e-08,
-        "v-offset": -2e-08
+        "v-range":  5.0e-07,
+        "v-offset": -2.5e-07
     }
 
 }

--- a/Config/LocustCavityCCA.json.in
+++ b/Config/LocustCavityCCA.json.in
@@ -14,7 +14,7 @@
         "cavity-length": 0.1,           
         "back-reaction": "true",
         "dho-cavity-frequency": 25.9e9,
-        "dho-time-resolution": 1.0e-9,
+        "dho-time-resolution": 1.0e-10,
         "dho-threshold-factor": 0.01,
         "event-spacing-samples": 10,
         "e-gun": false,        
@@ -40,8 +40,8 @@
 
     "digitizer":
     {
-        "v-range":  6.0,
-        "v-offset": -3.0
+        "v-range":  100.0,
+        "v-offset": -50.0
     }
 
 }


### PR DESCRIPTION
Ongoing unit tests are showing that the time resolution in the Green's functions can be further increased for higher fidelity.  Impact on simulation output is ~20% at pitch angles < 87 degrees.  This change has been implemented in the config files for the compiled examples, and will be released as a patch.

Unit test outputs at 1 GHz and 25.9 GHz are shown here:
![cavity1GHz](https://user-images.githubusercontent.com/6953145/223453256-e84fcccb-7176-4751-99e8-17dbb883eb1d.png)
![cavityCCA](https://user-images.githubusercontent.com/6953145/223453258-bce23bea-92e5-4296-940c-3ee440352ed8.png)
