### PR TITLE
Feature/polarization integration

### DIFF
--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -16,7 +16,7 @@ namespace locust
     	fProbeGain( 1.),
 		fCavityProbeZ( 0. ),
 		fCavityProbeRFrac( 0.5 ),
-		fCavityProbePhi( 0.0 ),
+		fCavityProbeTheta( 0.0 ),
 		fCavityVolume( 0. )
 		{}
 
@@ -57,9 +57,9 @@ namespace locust
     		SetCavityProbeRFrac(aParam["cavity-probe-r-fraction"]().as_double());
     	}
 
-     	if ( aParam.has( "cavity-probe-phi" ) )
+     	if ( aParam.has( "cavity-probe-theta" ) )
 	{
-		SetCavityProbePhi(aParam["cavity-probe-phi"]().as_double());
+		SetCavityProbeTheta(aParam["cavity-probe-theta"]().as_double());
 	}
 
         /*
@@ -273,19 +273,19 @@ namespace locust
     double CylindricalCavity::GetFieldAtProbe(int l, int m, int n, bool includeOtherPols, std::vector<double> tKassParticleXP)
 	{
     	double rProbe = this->GetCavityProbeRFrac() * this->GetDimR();
-	double phiProbe = this->GetCavityProbePhi();
+	double thetaProbe = this->GetCavityProbeTheta();
     	double zProbe = this->GetCavityProbeZ();
 
-	double phiEffective = phiProbe; 
+	double thetaEffective = thetaProbe; 
 	if(l>0)
 	{
-		//If mode has phi dependence, mode polarization is set by electron location. Probe coupling must be set relative to that angle
-		double phiElectron = tKassParticleXP[1];
-		phiEffective = phiProbe - phiElectron;
+		//If mode has theta dependence, mode polarization is set by electron location. Probe coupling must be set relative to that angle
+		double thetaElectron = tKassParticleXP[1];
+		thetaEffective = thetaProbe - thetaElectron;
 	}	
 
 
-		std::vector<double> tProbeLocation = {rProbe, phiEffective, zProbe};
+		std::vector<double> tProbeLocation = {rProbe, thetaEffective, zProbe};
 		// Factor of sqrt(fCavityVolume) is being applied to the pre-digitized E-fields
 		// to try to reduce dependence of detected power on cavity volume.  This
 		// is qualitatively consistent with the volume scaling expected from a cavity
@@ -298,11 +298,11 @@ namespace locust
     std::vector<double> CylindricalCavity::GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP, bool includeOtherPols)
     {
     	double tR = tKassParticleXP[0];
-    	double tPhi = tKassParticleXP[1];
+    	double tTheta = tKassParticleXP[1];
     	double tZ = tKassParticleXP[2];
        	std::vector<double> tField;
 
-       	tField = fFieldCore->TE_E(GetDimR(),GetDimL(),l,m,n,tR,tPhi,tZ,1);
+       	tField = fFieldCore->TE_E(GetDimR(),GetDimL(),l,m,n,tR,tTheta,tZ,includeOtherPols);
        	double normFactor = GetNormFactorsTE()[l][m][n];
    		auto it = tField.begin();
    		while (it != tField.end())
@@ -493,7 +493,7 @@ namespace locust
     			"# hTEtheta->SetLineWidth(0)\n"
     			"# TE011_Etheta->DrawCopy(\"pol lego2\")\n"
     			"# TPad *p = (TPad*)c1->cd()\n"
-    			"# p->SetTheta(90.); p->SetPhi(0.)\n"
+    			"# p->SetTheta(90.); p->SetTheta(0.)\n"
     			"# p->Update()\n"
     			"\n\nMode map files have been generated; press RETURN to continue, or Cntrl-C to quit.");
     	getchar();
@@ -525,13 +525,13 @@ namespace locust
     {
     	fCavityProbeRFrac = aFraction;
     }
-    double CylindricalCavity::GetCavityProbePhi()
+    double CylindricalCavity::GetCavityProbeTheta()
     {
-	return fCavityProbePhi;
+	return fCavityProbeTheta;
     }
-    void CylindricalCavity::SetCavityProbePhi ( double aPhi )
+    void CylindricalCavity::SetCavityProbeTheta ( double aTheta )
     {
-	fCavityProbePhi = aPhi;
+	fCavityProbeTheta = aTheta;
     }
 
 

--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -296,22 +296,13 @@ namespace locust
 	}
 
     std::vector<double> CylindricalCavity::GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP, bool includeOtherPols)
-       {
-       	double tR = tKassParticleXP[0];
-	double tPhi = tKassParticleXP[1];
-       	double tZ = tKassParticleXP[2];
+    {
+    	double tR = tKassParticleXP[0];
+    	double tPhi = tKassParticleXP[1];
+    	double tZ = tKassParticleXP[2];
        	std::vector<double> tField;
 
-       	tField = fFieldCore->TE_E(GetDimR(),GetDimL(),l,m,n,tR,tPhi,tZ,0);
-	if((l>0) and includeOtherPols){
-		//Calculates a convenient phase shift for a second polarization of fields with azimuthal dependence, calculates that field, and combines two polarizations to get the total field for the mode
-		double dPhi = LMCConst::Pi() / 2.0 / (double)l;
-		std::vector<double> tPolarization; 
-		tPolarization = fFieldCore->TE_E(GetDimR(),GetDimL(),l,m,n,tR,tPhi+dPhi,tZ,0);
-		tField[0] = tField[0]*sin((double)l*tPhi) + tPolarization[0]*cos((double)l*tPhi) ;
-		tField[1] = tField[1]*sin((double)l*(tPhi+dPhi)) + tPolarization[1]*cos((double)l*(tPhi+dPhi)) ;
-		//modifies both r and phi components of TE field before normalizing in the next loop. Scaled to have same amplitude as a single polarization
-	}
+       	tField = fFieldCore->TE_E(GetDimR(),GetDimL(),l,m,n,tR,tPhi,tZ,1);
        	double normFactor = GetNormFactorsTE()[l][m][n];
    		auto it = tField.begin();
    		while (it != tField.end())

--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -16,9 +16,7 @@ namespace locust
     	fProbeGain( 1.),
 		fCavityProbeZ( 0. ),
 		fCavityProbeRFrac( 0.5 ),
-		fCavityProbeTheta( 0.0 ),
-		fCavityVolume( 0. )
-
+		fCavityProbeTheta( 0.0 )
 		{}
 
     CylindricalCavity::~CylindricalCavity() {}
@@ -268,24 +266,18 @@ namespace locust
     double CylindricalCavity::GetFieldAtProbe(int l, int m, int n, bool includeOtherPols, std::vector<double> tKassParticleXP)
     {
     	double rProbe = this->GetCavityProbeRFrac() * this->GetDimR();
-      double thetaProbe = this->GetCavityProbeTheta();
+    	double thetaProbe = this->GetCavityProbeTheta();
     	double zProbe = this->GetCavityProbeZ();
-      double thetaEffective = thetaProbe; 
-      if(l>0)
-      {
-        //If mode has theta dependence, mode polarization is set by electron location. Probe coupling must be set relative to that angle
-        double thetaElectron = tKassParticleXP[1];
-        thetaEffective = thetaProbe - thetaElectron;
-      }	
+    	double thetaEffective = thetaProbe;
+    	if (l>0)
+    	{
+    		//If mode has theta dependence, mode polarization is set by electron location. Probe coupling must be set relative to that angle
+    		double thetaElectron = tKassParticleXP[1];
+    		thetaEffective = thetaProbe - thetaElectron;
+    	}
 
-
-      std::vector<double> tProbeLocation = {rProbe, thetaEffective, zProbe};
-      // Factor of sqrt(fCavityVolume) is being applied to the pre-digitized E-fields
-      // to try to reduce dependence of detected power on cavity volume.  This
-      // is qualitatively consistent with the volume scaling expected from a cavity
-      // experiment, and will also support ongoing normalization studies without
-      // necessarily having to retune the digitizer frequently.
-      double tEFieldAtProbe = sqrt(fCavityVolume) * GetNormalizedModeField(l,m,n,tProbeLocation,0).back(); //Assumes probe couples to E_theta of mode. If mode is polarized, transforms angle to reference frame of electron
+    	std::vector<double> tProbeLocation = {rProbe, thetaEffective, zProbe};
+    	double tEFieldAtProbe = GetNormalizedModeField(l,m,n,tProbeLocation,0).back(); //Assumes probe couples to E_theta of mode. If mode is polarized, transforms angle to reference frame of electron
 
     	return fProbeGain * tEFieldAtProbe;
     }
@@ -484,11 +476,11 @@ namespace locust
     	LPROG(lmclog, "\n\nTo plot a mode map:\n"
     			"> root file:output/ModeMapOutput.root\n"
     			"# _file0->ls()\n"
-    			"# hTEtheta->SetLineColor(0)\n"
-    			"# hTEtheta->SetLineWidth(0)\n"
+    			"# TE011_Etheta->SetLineColor(0)\n"
+    			"# TE011_Etheta->SetLineWidth(0)\n"
     			"# TE011_Etheta->DrawCopy(\"pol lego2\")\n"
     			"# TPad *p = (TPad*)c1->cd()\n"
-    			"# p->SetTheta(90.); p->SetTheta(0.)\n"
+    			"# p->SetTheta(90.); p->SetPhi(0.)\n"
     			"# p->Update()\n"
     			"\n\nMode map files have been generated; press RETURN to continue, or Cntrl-C to quit.");
     	getchar();

--- a/Source/Fields/LMCCylindricalCavity.hh
+++ b/Source/Fields/LMCCylindricalCavity.hh
@@ -59,8 +59,8 @@ namespace locust
             double GetCavityProbeRFrac();
             void SetCavityProbeRFrac ( double aFraction );
             double GetCavityProbeGain();
-            void SetCavityProbePhi( double aPhi );
-            double GetCavityProbePhi();
+            void SetCavityProbeTheta( double aTheta );
+            double GetCavityProbeTheta();
             void SetCavityProbeGain( double aGain );
             void SetCavityVolume();
 
@@ -69,7 +69,7 @@ namespace locust
             FieldCore* fFieldCore;
             double fCavityProbeZ;
             double fCavityProbeRFrac;
-            double fCavityProbePhi;
+            double fCavityProbeTheta;
             double fProbeGain;
             double fCavityVolume;
 

--- a/Source/Fields/LMCCylindricalCavity.hh
+++ b/Source/Fields/LMCCylindricalCavity.hh
@@ -47,18 +47,20 @@ namespace locust
             virtual double Z_TM(int l, int m, int n, double fcyc) const;
             virtual double Integrate(int l, int m, int n, bool teMode, bool eField);
             virtual std::vector<double> GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP);
-            virtual std::vector<double> GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP);
+            virtual std::vector<double> GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP, bool includeOtherPols);
             virtual std::vector<std::vector<std::vector<double>>> CalculateNormFactors(int nModes, bool bTE);
             virtual std::vector<double> GetTE_E(int l, int m, int n, double r, double theta, double z, bool includeOtherPols);
             virtual double GetDotProductFactor(std::vector<double> tKassParticleXP, std::vector<double> anE_normalized, bool IntermediateFile);
             virtual void CheckNormalization(int nModes);
             virtual void PrintModeMaps(int nModes, bool bTE, double zSlice);
-            virtual double GetFieldAtProbe(int l, int m, int n, bool includeOtherPols);
+            virtual double GetFieldAtProbe(int l, int m, int n, bool includeOtherPols, std::vector<double> tKassParticleXP);
             double GetCavityProbeZ();
             void SetCavityProbeZ ( double aZ );
             double GetCavityProbeRFrac();
             void SetCavityProbeRFrac ( double aFraction );
             double GetCavityProbeGain();
+            void SetCavityProbePhi( double aPhi );
+            double GetCavityProbePhi();
             void SetCavityProbeGain( double aGain );
             void SetCavityVolume();
 
@@ -67,6 +69,7 @@ namespace locust
             FieldCore* fFieldCore;
             double fCavityProbeZ;
             double fCavityProbeRFrac;
+            double fCavityProbePhi;
             double fProbeGain;
             double fCavityVolume;
 

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -35,10 +35,10 @@ namespace locust
     	    virtual ~FieldCore();
 
 	        // Cylindrical cavity:
-            virtual std::vector<double> TE_E(double R, double L, int l, int m, int n, double r, double theta, double z, bool avgOverTheta){return {0.};};
-            virtual std::vector<double> TE_H(double R, double L, int l, int m, int n, double r, double theta, double z, bool avgOverTheta){return {0.};};
-            virtual std::vector<double> TM_E(double R, double L, int l, int m, int n, double r, double theta, double z, bool avgOverTheta){return {0.};};
-            virtual std::vector<double> TM_H(double R, double L, int l, int m, int n, double r, double theta, double z, bool avgOverTheta){return {0.};};
+            virtual std::vector<double> TE_E(double R, double L, int l, int m, int n, double r, double theta, double z, bool includeOtherPols){return {0.};};
+            virtual std::vector<double> TE_H(double R, double L, int l, int m, int n, double r, double theta, double z, bool includeOtherPols){return {0.};};
+            virtual std::vector<double> TM_E(double R, double L, int l, int m, int n, double r, double theta, double z, bool includeOtherPols){return {0.};};
+            virtual std::vector<double> TM_H(double R, double L, int l, int m, int n, double r, double theta, double z, bool includeOtherPols){return {0.};};
 
             // Rectangular waveguide:
             virtual std::vector<double> TE_E(double dimX, double dimY, int m, int n, double xKass, double yKass, double fcyc){return {0.};};

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -73,12 +73,12 @@ namespace locust
             virtual std::vector<double> GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP) {return {0.};};
             virtual std::vector<double> GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP, bool includeOtherPols) {return {0.};};
             virtual std::vector<std::vector<std::vector<double>>> CalculateNormFactors(int nModes, bool bTE) {return {{{0.}}};};
-            virtual std::vector<double> GetTE_E(int l, int m, int n, double r, double theta, double z, bool avgOverTheta) {return {0.};};
+            virtual std::vector<double> GetTE_E(int l, int m, int n, double r, double theta, double z, bool includeOtherPols) {return {0.};};
             virtual double GetDotProductFactor(std::vector<double> tKassParticleXP, std::vector<double> aTE_E_normalized, bool IntermediateFile) {return {0.};};
             virtual void CheckNormalization(int nModes){};
             virtual void PrintModeMaps(int nModes, bool bTE, double zSlice){};
-            virtual double GetFieldAtProbe(int l, int m, int n, bool avgOverTheta){return 0.;};
-	    virtual double GetFieldAtProbe(int l, int m, int n, bool avgOverTheta, std::vector<double> tKassParticleXP){return 0.;};
+            virtual double GetFieldAtProbe(int l, int m, int n, bool includeOtherPols){return 0.;};
+	    virtual double GetFieldAtProbe(int l, int m, int n, bool includeOtherPols, std::vector<double> tKassParticleXP){return 0.;};
 
             std::vector<std::vector<std::vector<double>>> GetNormFactorsTE();
             void SetNormFactorsTE(std::vector<std::vector<std::vector<double>>> aNormFactor);

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -79,7 +79,7 @@ namespace locust
             virtual void PrintModeMaps(int nModes, bool bTE, double zSlice){};
             virtual double GetFieldAtProbe(int l, int m, int n, bool includeOtherPols){return 0.;};
             virtual double GetFieldAtProbe(int l, int m, int n, bool includeOtherPols, std::vector<double> tKassParticleXP){return 0.;};
-
+            virtual double ScaleEPoyntingVector(double fcyc){return 0.;};
 
             std::vector<std::vector<std::vector<double>>> GetNormFactorsTE();
             void SetNormFactorsTE(std::vector<std::vector<std::vector<double>>> aNormFactor);

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -71,13 +71,14 @@ namespace locust
             virtual double Integrate(int l, int m, int n, bool teMode, bool eField){return 0.;};
             virtual std::vector<double> GetDopplerFrequency(int l, int m, int n, std::vector<double> tKassParticleXP) {return {0.};};
             virtual std::vector<double> GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP) {return {0.};};
+            virtual std::vector<double> GetNormalizedModeField(int l, int m, int n, std::vector<double> tKassParticleXP, bool includeOtherPols) {return {0.};};
             virtual std::vector<std::vector<std::vector<double>>> CalculateNormFactors(int nModes, bool bTE) {return {{{0.}}};};
             virtual std::vector<double> GetTE_E(int l, int m, int n, double r, double theta, double z, bool avgOverTheta) {return {0.};};
             virtual double GetDotProductFactor(std::vector<double> tKassParticleXP, std::vector<double> aTE_E_normalized, bool IntermediateFile) {return {0.};};
             virtual void CheckNormalization(int nModes){};
             virtual void PrintModeMaps(int nModes, bool bTE, double zSlice){};
             virtual double GetFieldAtProbe(int l, int m, int n, bool avgOverTheta){return 0.;};
-
+	    virtual double GetFieldAtProbe(int l, int m, int n, bool avgOverTheta, std::vector<double> tKassParticleXP){return 0.;};
 
             std::vector<std::vector<std::vector<double>>> GetNormFactorsTE();
             void SetNormFactorsTE(std::vector<std::vector<std::vector<double>>> aNormFactor);

--- a/Source/Fields/LMCPozarCylindricalCavity.cc
+++ b/Source/Fields/LMCPozarCylindricalCavity.cc
@@ -43,11 +43,11 @@ namespace locust
 
     	if ((includeOtherPols)&&(l>0))
     	{
-    		//modifies both r and phi components of TE field.
-    		double dPhi = LMCConst::Pi() / 2.0 / (double)l;
-    		std::vector<double> tPolarization{tEr, tEtheta};
+    		//modifies both r and theta components of TE field.
+    		double dTheta = LMCConst::Pi() / 2.0 / (double)l;
+    		std::vector<double> tPolarization = this->TE_E(R,L,l,m,n,r,theta+dTheta,zKass,0);
     		tEr = tEr*sin((double)l*theta) + tPolarization[0]*cos((double)l*theta) ;
-    		tEtheta = tEtheta*sin((double)l*(theta+dPhi)) + tPolarization[1]*cos((double)l*(theta+dPhi)) ;
+    		tEtheta = tEtheta*sin((double)l*(theta+dTheta)) + tPolarization[1]*cos((double)l*(theta+dTheta)) ;
     	}
 
     	TE_E.push_back(tEr);

--- a/Source/Fields/LMCPozarCylindricalCavity.cc
+++ b/Source/Fields/LMCPozarCylindricalCavity.cc
@@ -38,21 +38,17 @@ namespace locust
     	double tEr = 0.;
     	double tEtheta = 0.;
 
-    	if ((!includeOtherPols)||(l==0))
-    	{
-        	tEr = -l * k/k1 * eta * jl_of_k1r_by_k1r * sin(l*theta) * sin(k3*z);
-    		tEtheta = -k/k1 * eta * jPrime * cos(l*theta) * sin(k3*z);
-    	}
-    	else
-    	{
-    		LERROR(lmclog,"This superposition has not yet been implemented.");
-    		exit(-1);
-    		// Possible suggestion:
-    		// Here we can implement the superposition with other polarities of the same mode.
-    		// The superposition can be done either in this function itself, or with some kind
-    		// of new helper function in this class.
-    	}
+    	tEr = -l * k/k1 * eta * jl_of_k1r_by_k1r * sin(l*theta) * sin(k3*z);
+    	tEtheta = -k/k1 * eta * jPrime * cos(l*theta) * sin(k3*z);
 
+    	if ((includeOtherPols)&&(l>0))
+    	{
+    		//modifies both r and phi components of TE field.
+    		double dPhi = LMCConst::Pi() / 2.0 / (double)l;
+    		std::vector<double> tPolarization{tEr, tEtheta};
+    		tEr = tEr*sin((double)l*theta) + tPolarization[0]*cos((double)l*theta) ;
+    		tEtheta = tEtheta*sin((double)l*(theta+dPhi)) + tPolarization[1]*cos((double)l*(theta+dPhi)) ;
+    	}
 
     	TE_E.push_back(tEr);
     	TE_E.push_back(tEtheta);

--- a/Source/Fields/LMCRectangularWaveguide.cc
+++ b/Source/Fields/LMCRectangularWaveguide.cc
@@ -414,6 +414,8 @@ namespace locust
     	LPROG(lmclog, "\n\nTo plot a mode map:\n"
     			"> root file:output/ModeMapOutput.root\n"
     			"# _file0->ls()\n"
+    			"# TE10_Ey->SetLineColor(0)\n"
+    			"# TE10_Ey->SetLineWidth(0)\n"
     			"# TE10_Ey->DrawCopy(\"colz\")\n"
     			"\n\nMode map files have been generated; press RETURN to continue, or Cntrl-C to quit.");
     	getchar();

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -440,8 +440,7 @@ namespace locust
     					double cavityFIRSample = fFieldCalculator->GetCavityFIRSample(tKassParticleXP, fBypassTF).first;
     					dopplerFrequency = fInterface->fField->GetDopplerFrequency(l, m, n, tKassParticleXP);
     					fAvgDotProductFactor = 1. / ( tThisEventNSamples + 1 ) * ( fAvgDotProductFactor * tThisEventNSamples + fInterface->fField->GetDotProductFactor(tKassParticleXP, tE_normalized, fIntermediateFile) );  // unit velocity \dot unit theta
-					double theta_sign = tE_normalized.back() / fabs(tE_normalized.back()); // retains sign of theta component to incorporate into modeAmplitude
-    					double modeAmplitude = theta_sign * sqrt( tE_normalized.front()*tE_normalized.front()  + tE_normalized.back()*tE_normalized.back());
+    					double modeAmplitude = sqrt( tE_normalized.front()*tE_normalized.front()  + tE_normalized.back()*tE_normalized.back());
 //                                        double modeAmplitude = tE_normalized.back();
 
     					if (!fInterface->fE_Gun)

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -410,7 +410,7 @@ namespace locust
     					tE_normalized = fInterface->fField->GetNormalizedModeField(l,m,n,tKassParticleXP,1);
     					double cavityFIRSample = fFieldCalculator->GetCavityFIRSample(tKassParticleXP, fBypassTF).first;
     					dopplerFrequency = fInterface->fField->GetDopplerFrequency(l, m, n, tKassParticleXP);
-    					fAvgDotProductFactor = 1. / ( tThisEventNSamples + 1 ) * ( fAvgDotProductFactor * tThisEventNSamples + fInterface->fField->GetDotProductFactor(tKassParticleXP, tE_normalized, fIntermediateFile) );  // unit velocity \dot unit theta
+    					fAvgDotProductFactor[l][m][n] = 1. / ( tThisEventNSamples + 1 ) * ( fAvgDotProductFactor[l][m][n] * tThisEventNSamples + fInterface->fField->GetDotProductFactor(tKassParticleXP, tE_normalized, fIntermediateFile) );  // unit velocity \dot unit theta
     					double modeAmplitude = sqrt( tE_normalized.front()*tE_normalized.front()  + tE_normalized.back()*tE_normalized.back());
 
 
@@ -419,7 +419,7 @@ namespace locust
     						// sqrt(4PIeps0) for Kass current si->cgs, sqrt(4PIeps0) for Jackson A_lambda coefficient cgs->si
     						unitConversion = 1. / LMCConst::FourPiEps(); // see comment ^
     						// Calculate propagating E-field with J \dot E.  cavityFIRSample units are [current]*[unitless].
-    						excitationAmplitude = fAvgDotProductFactor * modeAmplitude * cavityFIRSample * fInterface->fField->Z_TE(l,m,n,tKassParticleXP[7]) * 2. * LMCConst::Pi() / LMCConst::C() / 1.e2;
+    						excitationAmplitude = fAvgDotProductFactor[l][m][n] * modeAmplitude * cavityFIRSample * fInterface->fField->Z_TE(l,m,n,tKassParticleXP[7]) * 2. * LMCConst::Pi() / LMCConst::C() / 1.e2;
     						tEFieldAtProbe = fInterface->fField->GetFieldAtProbe(l,m,n,1,tKassParticleXP);
     					}
     					else

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -77,7 +77,7 @@ namespace locust
     	{
     		if (!fNormCheck)
     		{
-    			if ((l==1)&&(m==1)&&(n==1))
+    			if ((l==0)&&(m==1)&&(n==1))
     				return true;
     			else
     				return false;
@@ -440,8 +440,9 @@ namespace locust
     					double cavityFIRSample = fFieldCalculator->GetCavityFIRSample(tKassParticleXP, fBypassTF).first;
     					dopplerFrequency = fInterface->fField->GetDopplerFrequency(l, m, n, tKassParticleXP);
     					fAvgDotProductFactor = 1. / ( tThisEventNSamples + 1 ) * ( fAvgDotProductFactor * tThisEventNSamples + fInterface->fField->GetDotProductFactor(tKassParticleXP, tE_normalized, fIntermediateFile) );  // unit velocity \dot unit theta
-    					double modeAmplitude = tE_normalized.back();
-
+					double theta_sign = tE_normalized.back() / fabs(tE_normalized.back()); // retains sign of theta component to incorporate into modeAmplitude
+    					double modeAmplitude = theta_sign * sqrt( tE_normalized.front()*tE_normalized.front()  + tE_normalized.back()*tE_normalized.back());
+//                                        double modeAmplitude = tE_normalized.back();
 
     					if (!fInterface->fE_Gun)
     					{

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -77,7 +77,7 @@ namespace locust
     	{
     		if (!fNormCheck)
     		{
-    			if ((l==0)&&(m==1)&&(n==1))
+    			if ((l==1)&&(m==1)&&(n==1))
     				return true;
     			else
     				return false;
@@ -436,7 +436,7 @@ namespace locust
     				if (ModeSelect(l, m, n, fInterface->fE_Gun))
     				{
     					std::vector<double> tE_normalized;
-    					tE_normalized = fInterface->fField->GetNormalizedModeField(l,m,n,tKassParticleXP);
+    					tE_normalized = fInterface->fField->GetNormalizedModeField(l,m,n,tKassParticleXP,1);
     					double cavityFIRSample = fFieldCalculator->GetCavityFIRSample(tKassParticleXP, fBypassTF).first;
     					dopplerFrequency = fInterface->fField->GetDopplerFrequency(l, m, n, tKassParticleXP);
     					fAvgDotProductFactor = 1. / ( tThisEventNSamples + 1 ) * ( fAvgDotProductFactor * tThisEventNSamples + fInterface->fField->GetDotProductFactor(tKassParticleXP, tE_normalized, fIntermediateFile) );  // unit velocity \dot unit theta
@@ -449,7 +449,7 @@ namespace locust
     						unitConversion = 1. / LMCConst::FourPiEps(); // see comment ^
     						// Calculate propagating E-field with J \dot E.  cavityFIRSample units are [current]*[unitless].
     						excitationAmplitude = fAvgDotProductFactor * modeAmplitude * cavityFIRSample * fInterface->fField->Z_TE(l,m,n,tKassParticleXP[7]) * 2. * LMCConst::Pi() / LMCConst::C() / 1.e2;
-    						tEFieldAtProbe = fInterface->fField->GetFieldAtProbe(l,m,n,1);
+    						tEFieldAtProbe = fInterface->fField->GetFieldAtProbe(l,m,n,1,tKassParticleXP);
     					}
     					else
     					{

--- a/Source/RxComponents/LMCCavityModes.cc
+++ b/Source/RxComponents/LMCCavityModes.cc
@@ -56,8 +56,9 @@ namespace locust
 		double dopplerFrequency = cavityDopplerFrequency[0];
         SetVoltagePhase( GetVoltagePhase() + dopplerFrequency * dt ) ;
         double voltageValue = excitationAmplitude * EFieldAtProbe;
+	//std::cout << "Amp, FieldAtProbe, Product: " << excitationAmplitude << " " << EFieldAtProbe << " " << voltageValue << std::endl;
         voltageValue *= cos(GetVoltagePhase());
-
+	
         aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2. * voltageValue * totalScalingFactor * sin(phi_LO);
         aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2. * voltageValue * totalScalingFactor * cos(phi_LO);
 


### PR DESCRIPTION
New version of alternate mode implementation which better fits restructuring of Field classes for cylindrical cavities. Defaults to using TE011 mode, but expanded to implement higher order l>0 modes for TE_lmn with arbitrary polarizations based on electron location.