### PR TITLE
Feature/waveguide tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/waveguideTests]
     tags: ['*']
   workflow_dispatch:
 

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -162,6 +162,7 @@ namespace locust
         }
 
         fPowerCombiner->SetNCavityModes(fInterface->fField->GetNModes());
+
         if(!fPowerCombiner->Configure(aParam))
 		{
 			LERROR(lmclog,"Error configuring PowerCombiner.");
@@ -501,6 +502,8 @@ namespace locust
 
     bool CavitySignalGenerator::DoGenerateTime( Signal* aSignal )
     {
+
+    	fPowerCombiner->SizeNChannels(fNChannels);
  		if (fNChannels > 2)
  		{
     		LERROR(lmclog,"The cavity simulation only supports up to 2 channels right now.");

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -74,11 +74,18 @@ namespace locust
                 // TO-DO:  Change seed here, for pileup tests.
             }
 
-
             if( aParam.has( "waveguide-x" ) )
             {
-            	// TO-DO:  Adjust Kass waveguide dimensions here.  Use fToolbox.
-
+            	// TO-DO:  Adjust Kass waveguide dimensions here.  The below syntax
+            	// is a first attempt.  Unfortunately it is not yet finding the parameter
+				// in the xml file.
+            	/*
+                for( auto sim : fToolbox.GetAll<KGeoBag::KGBoxSpace>("new_rectangularwaveguide_space"))
+                {
+                	// std::cout << "seed is " << sim->GetSeed();
+                    // TO-DO:  Change seed here, for pileup tests.
+                }
+                */
             }
 
 

--- a/Source/RxComponents/LMCCavityModes.cc
+++ b/Source/RxComponents/LMCCavityModes.cc
@@ -61,21 +61,31 @@ namespace locust
             }
         }
 
-	int nchannels = 2; //TO-DO:  Configure this as LMCGenerator::fNChannels.
-        fVoltagePhase.resize(nchannels); // max nchannels.  TO-DO:  Configure this as LMCGenerator::fNChannels.
-        for (int n = 0; n < GetNCavityModes(); n++)
-        {
-            fVoltagePhase[n].resize(GetNCavityModes());
-            for (int i = 0; i < GetNCavityModes(); i++)
-            {
-            	fVoltagePhase[n][i].resize(GetNCavityModes());
-            	for (int j = 0; j < GetNCavityModes(); j++)
-            	{
-            		fVoltagePhase[n][i][j].resize(GetNCavityModes());
-            	}
-            }
-        }
+        SizeNChannels(GetNChannels());
 
+    	return true;
+    }
+
+    bool CavityModes::SizeNChannels(int aNumberOfChannels)
+    {
+    	SetNChannels(aNumberOfChannels);
+
+    	std::vector<std::vector<std::vector<std::vector<double>>>> tZeroVector;
+    	fVoltagePhase.swap(tZeroVector);
+    	fVoltagePhase.resize(aNumberOfChannels);
+
+    	for (int n = 0; n < GetNChannels(); n++)
+    	{
+    		fVoltagePhase[n].resize(GetNCavityModes());
+    		for (int i = 0; i < GetNCavityModes(); i++)
+    		{
+    			fVoltagePhase[n][i].resize(GetNCavityModes());
+    			for (int j = 0; j < GetNCavityModes(); j++)
+    			{
+    				fVoltagePhase[n][i][j].resize(GetNCavityModes());
+    			}
+    		}
+    	}
 
     	return true;
     }

--- a/Source/RxComponents/LMCCavityModes.hh
+++ b/Source/RxComponents/LMCCavityModes.hh
@@ -40,7 +40,8 @@ namespace locust
         	virtual bool AddOneSampleToRollingAvg(int l, int m, int n, double excitationAmplitude, unsigned sampleIndex);
             double GetVoltagePhase(int aChannel, int l, int m, int n);
             void SetVoltagePhase( double aPhase, int aChannel, int l, int m, int n);
-        	bool WriteRootHisto();
+            virtual bool SizeNChannels(int aNumberOfChannels);
+            bool WriteRootHisto();
 
 
 

--- a/Source/RxComponents/LMCPowerCombiner.cc
+++ b/Source/RxComponents/LMCPowerCombiner.cc
@@ -25,6 +25,7 @@ namespace locust
             fjunctionResistance( 0.3 ),
 			fvoltageCheck( false ),
 			fNCavityModes( 0 ),
+			fNChannels( 2 ),
 			fWaveguideShortIsPresent( true )
     {}
     PowerCombiner::~PowerCombiner() {}
@@ -32,7 +33,6 @@ namespace locust
 
     bool PowerCombiner::Configure( const scarab::param_node& aParam )
     {
-
     	if ( aParam.has( "voltage-check" ) )
     	{
     		fvoltageCheck = aParam["voltage-check"]().as_bool();
@@ -158,6 +158,14 @@ namespace locust
     void PowerCombiner::SetNCavityModes( int aNumberOfModes )
     {
      	fNCavityModes = aNumberOfModes;
+    }
+    int PowerCombiner::GetNChannels()
+    {
+        return fNChannels;
+    }
+    void PowerCombiner::SetNChannels( int aNumberOfChannels )
+    {
+     	fNChannels = aNumberOfChannels;
     }
     bool PowerCombiner::GetWaveguideShortIsPresent()
     {

--- a/Source/RxComponents/LMCPowerCombiner.hh
+++ b/Source/RxComponents/LMCPowerCombiner.hh
@@ -62,8 +62,11 @@ namespace locust
             bool GetVoltageCheck();
             void SetNCavityModes( int aNumberOfModes );
             int GetNCavityModes();
+            void SetNChannels( int aNumberOfChannels );
+            int GetNChannels();
             double GetVoltagePhase();
             void SetVoltagePhase( double aPhase );
+            virtual bool SizeNChannels(int aNumberOfChannels) {return true;};
 
             bool GetWaveguideShortIsPresent();
             void SetWaveguideShortIsPresent ( bool aValue );
@@ -80,6 +83,7 @@ namespace locust
             double fjunctionResistance;
             bool fvoltageCheck;
             int fNCavityModes;
+            int fNChannels;
             bool fWaveguideShortIsPresent;
 
 

--- a/Source/RxComponents/LMCWaveguideModes.cc
+++ b/Source/RxComponents/LMCWaveguideModes.cc
@@ -35,7 +35,40 @@ namespace locust
     		return false;
     	}
 
+    	SizeNChannels(GetNChannels());
+
     	return true;
+    }
+
+    bool WaveguideModes::SizeNChannels(int aNumberOfChannels)
+    {
+
+    	SetNChannels(aNumberOfChannels);
+
+    	std::vector<std::vector<std::vector<std::vector<double>>>> tZeroVector;
+    	fVoltagePhaseAntenna.swap(tZeroVector);
+    	fVoltagePhaseShort.swap(tZeroVector);
+    	fVoltagePhaseAntenna.resize(aNumberOfChannels);
+    	fVoltagePhaseShort.resize(aNumberOfChannels);
+
+    	for (int n = 0; n < GetNChannels(); n++)
+    	{
+    		fVoltagePhaseAntenna[n].resize(GetNCavityModes());
+    		fVoltagePhaseShort[n].resize(GetNCavityModes());
+    		for (int i = 0; i < GetNCavityModes(); i++)
+    		{
+    			fVoltagePhaseAntenna[n][i].resize(GetNCavityModes());
+    			fVoltagePhaseShort[n][i].resize(GetNCavityModes());
+    			for (int j = 0; j < GetNCavityModes(); j++)
+    			{
+    				fVoltagePhaseAntenna[n][i][j].resize(GetNCavityModes());
+    				fVoltagePhaseShort[n][i][j].resize(GetNCavityModes());
+    			}
+    		}
+    	}
+
+    	return true;
+
     }
 
     double WaveguideModes::GroupVelocity(double fcyc, double aDimX)
@@ -46,7 +79,7 @@ namespace locust
     	return groupVelocity;
     }
 
-    bool WaveguideModes::InitializeVoltagePhases(std::vector<double> tKassParticleXP, std::vector<double> dopplerFrequency)
+    bool WaveguideModes::InitializeVoltagePhases(std::vector<double> tKassParticleXP, std::vector<double> dopplerFrequency, int aChannel, int l, int m, int n)
     {
     	double fcyc = tKassParticleXP[7]/2./LMCConst::Pi(); // cycles/sec
     	double tPositionZ = tKassParticleXP[2];
@@ -54,18 +87,17 @@ namespace locust
     	double aCenterToShort = fInterface->fCENTER_TO_SHORT;
     	double aDimX = fInterface->fField->GetDimX();
 
-
         double tVoltagePhaseAntenna = 2.*LMCConst::Pi()*(aCenterToAntenna - tPositionZ) / (GroupVelocity(fcyc, aDimX) / dopplerFrequency[0]);
-        SetVoltagePhaseAntenna( tVoltagePhaseAntenna );
+        SetVoltagePhaseAntenna( tVoltagePhaseAntenna, aChannel, l, m, n );
 
         double tVoltagePhaseShort = LMCConst::Pi()/2. + 2.*LMCConst::Pi()*(aCenterToShort + aCenterToAntenna) /
                 (GroupVelocity(fcyc, aDimX) / dopplerFrequency[1]);  // phase of reflected field at antenna.
-        SetVoltagePhaseShort( tVoltagePhaseShort );
+        SetVoltagePhaseShort( tVoltagePhaseShort, aChannel, l, m, n );
 
     	return true;
     }
 
-	bool WaveguideModes::AddOneModeToCavityProbe(Signal* aSignal, std::vector<double> particleXP, double excitationAmplitude, double EFieldAtProbe, std::vector<double> dopplerFrequency, double dt, double phi_LO, double totalScalingFactor, unsigned sampleIndex, int channelIndex, bool initParticle)
+	bool WaveguideModes::AddOneModeToCavityProbe(int l, int m, int n, Signal* aSignal, std::vector<double> particleXP, double excitationAmplitude, double EFieldAtProbe, std::vector<double> dopplerFrequency, double dt, double phi_LO, double totalScalingFactor, unsigned sampleIndex, int channelIndex, bool initParticle)
 	{
 
 		double dopplerFrequencyAntenna = dopplerFrequency.front();
@@ -73,52 +105,52 @@ namespace locust
 
 		if (initParticle)
 		{
-			InitializeVoltagePhases(particleXP, dopplerFrequency);
+			InitializeVoltagePhases(particleXP, dopplerFrequency, channelIndex, l, m, n);
 		}
 
-
-		SetVoltagePhaseAntenna( GetVoltagePhaseAntenna() + dopplerFrequencyAntenna * dt);
-		SetVoltagePhaseShort( GetVoltagePhaseShort() + dopplerFrequencyShort * dt);
+		double newPhaseAntenna = GetVoltagePhaseAntenna(channelIndex, l, m, n) + dopplerFrequencyAntenna * dt;
+		double newPhaseShort = GetVoltagePhaseShort(channelIndex, l, m, n) + dopplerFrequencyShort * dt;
+		SetVoltagePhaseAntenna( newPhaseAntenna, channelIndex, l, m, n);
+		SetVoltagePhaseShort( newPhaseShort, channelIndex, l, m, n);
 
 		double voltageValue = excitationAmplitude;
 
 		if ( GetWaveguideShortIsPresent() ) // with short:
 		{
-			voltageValue *= ( cos(GetVoltagePhaseAntenna()) + cos(GetVoltagePhaseShort()) );
+			voltageValue *= ( cos(GetVoltagePhaseAntenna(channelIndex, l, m, n)) + cos(GetVoltagePhaseShort(channelIndex, l, m, n)) );
 			aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2. * voltageValue * totalScalingFactor * sin(phi_LO);
 	    	aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2. * voltageValue * totalScalingFactor * cos(phi_LO);
 		}
 		else // without short:
 		{
-			voltageValue *= cos(GetVoltagePhaseAntenna());
+			voltageValue *= cos(GetVoltagePhaseAntenna(channelIndex, l, m, n));
     		aSignal->LongSignalTimeComplex()[sampleIndex][0] += 2. * voltageValue * totalScalingFactor * sin(phi_LO);
 	    	aSignal->LongSignalTimeComplex()[sampleIndex][1] += 2. * voltageValue * totalScalingFactor * cos(phi_LO);
 		}
 
-
-		if ( GetVoltageCheck() && (sampleIndex%1000 < 1) )
+		if ( GetVoltageCheck() && (sampleIndex%100 < 1) )
 			LPROG( lmclog, "Voltage " << sampleIndex << " is <" << aSignal->LongSignalTimeComplex()[sampleIndex][1] << ">" );
 
 		return true;
 	}
 
-    double WaveguideModes::GetVoltagePhaseAntenna()
+    double WaveguideModes::GetVoltagePhaseAntenna(int aChannel, int l, int m, int n)
     {
-    	return fVoltagePhaseAntenna;
+    	return fVoltagePhaseAntenna[aChannel][l][m][n];
     }
-    void WaveguideModes::SetVoltagePhaseAntenna ( double aPhase )
+    void WaveguideModes::SetVoltagePhaseAntenna( double aPhase, int aChannel, int l, int m, int n )
     {
-        fVoltagePhaseAntenna = aPhase;
+        fVoltagePhaseAntenna[aChannel][l][m][n] = aPhase;
+    }
+    double WaveguideModes::GetVoltagePhaseShort(int aChannel, int l, int m, int n)
+    {
+    	return fVoltagePhaseShort[aChannel][l][m][n];
+    }
+    void WaveguideModes::SetVoltagePhaseShort( double aPhase, int aChannel, int l, int m, int n )
+    {
+        fVoltagePhaseShort[aChannel][l][m][n] = aPhase;
     }
 
-    double WaveguideModes::GetVoltagePhaseShort()
-    {
-    	return fVoltagePhaseShort;
-    }
-    void WaveguideModes::SetVoltagePhaseShort ( double aPhase )
-    {
-        fVoltagePhaseShort = aPhase;
-    }
 
 
 

--- a/Source/RxComponents/LMCWaveguideModes.hh
+++ b/Source/RxComponents/LMCWaveguideModes.hh
@@ -34,19 +34,20 @@ namespace locust
             WaveguideModes();
             virtual ~WaveguideModes();
             virtual bool Configure( const scarab::param_node& aNode );
-        	virtual bool AddOneModeToCavityProbe(Signal* aSignal, std::vector<double> particleXP, double excitationAmplitude, double EFieldAtProbe, std::vector<double> dopplerFrequency, double dt, double phi_LO, double totalScalingFactor, unsigned sampleIndex, int channelIndex, bool initParticle);
-            double GetVoltagePhaseAntenna();
-            void SetVoltagePhaseAntenna( double aPhase );
-            double GetVoltagePhaseShort();
-            void SetVoltagePhaseShort( double aPhase );
+        	virtual bool AddOneModeToCavityProbe(int l, int m, int n, Signal* aSignal, std::vector<double> particleXP, double excitationAmplitude, double EFieldAtProbe, std::vector<double> dopplerFrequency, double dt, double phi_LO, double totalScalingFactor, unsigned sampleIndex, int channelIndex, bool initParticle);
+            double GetVoltagePhaseAntenna(int aChannel, int l, int m, int n);
+            void SetVoltagePhaseAntenna( double aPhase, int aChannel, int l, int m, int n);
+            double GetVoltagePhaseShort(int aChannel, int l, int m, int n);
+            void SetVoltagePhaseShort( double aPhase, int aChannel, int l, int m, int n);
+            virtual bool SizeNChannels(int aNumberOfChannels);
 
 
 
         private:
-            bool InitializeVoltagePhases(std::vector<double> tKassParticleXP, std::vector<double> dopplerFrequency);
+            bool InitializeVoltagePhases(std::vector<double> tKassParticleXP, std::vector<double> dopplerFrequency, int aChannel, int l, int m, int n);
             double GroupVelocity(double fcyc, double aDimX);
-            double fVoltagePhaseAntenna;
-            double fVoltagePhaseShort;
+            std::vector<std::vector<std::vector<std::vector<double>>>> fVoltagePhaseAntenna;
+            std::vector<std::vector<std::vector<std::vector<double>>>> fVoltagePhaseShort;
             kl_interface_ptr_t fInterface;
 
 


### PR DESCRIPTION
Draft changes to make the rectangular waveguide simulation more compatible with the present cavity calculations.  Initial cluster tests with coarsely binned electron starting positions look reasonable.  More work is still needed e.g. to handle exceptions for electron starting positions outside the waveguide.
![2DpowerWaveguideXY](https://github.com/project8/locust_mc/assets/6953145/20bc3b6d-f7e1-4e80-b511-306b15387325)
