### PR TITLE
Feature/allow zvariation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/allowZvariation]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/allowZvariation]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ on:
 env:
   REGISTRY: ghcr.io
   BASE_IMG_REPO: project8/kassiopeia_builder
-  BASE_IMG_TAG: v4.0.0
+  BASE_IMG_TAG: v4.0.0-dev
   FINAL_BASE_IMG_REPO: project8/luna_base
-  FINAL_BASE_IMG_TAG: v1.3.3
+  FINAL_BASE_IMG_TAG: v1.3.4
   locust_mc_BUILD_WITH_KASSIOPEIA: ON
   locust_mc_ENABLE_EXECUTABLES: ON
   NARG: 2
@@ -94,7 +94,7 @@ jobs:
           load: true
           build-args: |
             img_repo=${{ env.REGISTRY }}/${{ env.BASE_IMG_REPO }}
-            img_tag=${{ env.BASE_IMG_TAG }}-dev
+            img_tag=${{ env.BASE_IMG_TAG }}
             final_img_repo=${{ env.REGISTRY }}/${{ env.FINAL_BASE_IMG_REPO }}
             final_img_tag=${{ env.FINAL_BASE_IMG_TAG }}${{ matrix.tag-suffix }}
             locust_tag=${{ steps.tag_name.outputs.tag }}
@@ -125,7 +125,7 @@ jobs:
           load: false
           build-args: |
             build_img_repo=${{ env.REGISTRY }}/${{ env.BASE_IMG_REPO }}
-            build_img_tag=${{ env.BASE_IMG_TAG }}-dev
+            build_img_tag=${{ env.BASE_IMG_TAG }}
             final_img_repo=${{ env.REGISTRY }}/${{ env.FINAL_BASE_IMG_REPO }}
             final_img_tag=${{ env.FINAL_BASE_IMG_TAG }}${{ matrix.tag-suffix }}
             locust_tag=${{ steps.tag_name.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG final_img_repo=ghcr.io/project8/luna_base
-ARG final_img_tag=v1.3.3
+ARG final_img_tag=v1.3.4
 
 ARG build_img_repo=ghcr.io/project8/kassiopeia_builder
 ARG build_img_tag=v4.0.0-dev

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -535,6 +535,7 @@ namespace locust
                     {
                         fInterface->fPreEventInProgress = false;  // reset.
                         fInterface->fEventInProgress = true;
+                        fFieldCalculator->SetSignalStartCondition( false ); // reset
                         LPROG( lmclog, "LMC about to WakeBeforeEvent()" );
                         WakeBeforeEvent();  // trigger Kass event.
                     }

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -62,7 +62,7 @@ namespace locust
 
         if( aParam.has( "locust-signal-zstart" ) )
         {
-        	fZSignalStart = aParam["locust-signal-zstart"]().as_bool();
+        	fZSignalStart = aParam["locust-signal-zstart"]().as_double();
     		LPROG(lmclog,"Starting signal calculation when e- z-position > " << fZSignalStart << " m.");
         }
 

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -18,6 +18,7 @@ namespace locust
     FieldCalculator::FieldCalculator() :
     		fNFilterBinsRequired( 0 ),
 			fbMultiMode( false ),
+			fDelaySignalTime( 0. ),
 			fTFReceiverHandler( NULL ),
 			fAnalyticResponseFunction( 0 ),
 			fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
@@ -26,6 +27,7 @@ namespace locust
     FieldCalculator::FieldCalculator( const FieldCalculator& aCopy ) :
     		fNFilterBinsRequired( 0 ),
 			fbMultiMode( false ),
+			fDelaySignalTime( 0. ),
 			fTFReceiverHandler( NULL ),
 			fAnalyticResponseFunction( 0 ),
 			fInterface( aCopy.fInterface )
@@ -55,6 +57,12 @@ namespace locust
 
     bool FieldCalculator::Configure( const scarab::param_node& aParam )
      {
+
+        if( aParam.has( "locust-signal-delay" ) )
+        {
+        	fDelaySignalTime = aParam["locust-signal-delay"]().as_bool();
+    		LPROG(lmclog,"Delaying signal ring-up by " << fDelaySignalTime << " seconds.");
+        }
 
         if( aParam.has( "multi-mode" ) )
         {
@@ -406,8 +414,9 @@ namespace locust
     	double vMag = pow(tVx*tVx + tVy*tVy,0.5);
     	double orbitPhase = tKassParticleXP[6];  // radians
     	double cycFrequency = tKassParticleXP[7];
+    	double tTime = tKassParticleXP[9];
     	double amplitude = 0.;
-    	if (fInterface->fField->InVolume(tKassParticleXP))
+    	if ( (tTime > fDelaySignalTime) && (fInterface->fField->InVolume(tKassParticleXP)) )
     	{
     		amplitude = 1.;
     	}

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -323,13 +323,19 @@ namespace locust
 
     	// l, m, & n are needed for selecting the resonant frequency and Q.  (Still TO-DO).
 
-    	// Extract particle at back of deque, by default if !Interpolate as in:
-    	std::vector<double> tKassParticleXP = fInterface->fTransmitter->ExtractParticleXP(0., false, 0., false);
-    	double tVx = tKassParticleXP[3];
-    	double tVy = tKassParticleXP[4];
+    	double tposX = aFinalParticle.GetPosition().X();
+    	double tposY = aFinalParticle.GetPosition().Y();
+    	double tposZ = aFinalParticle.GetPosition().Z();
+    	double tVx = aFinalParticle.GetVelocity().X();
+    	double tVy = aFinalParticle.GetVelocity().Y();
+    	double tVz = aFinalParticle.GetVelocity().Z();
+    	double orbitPhase = calcOrbitPhase(tVx, tVy);
+    	double fCyc = aFinalParticle.GetCyclotronFrequency() * 2. * LMCConst::Pi();
+
+    	std::vector<double> tKassParticleXP = {tposX, tposY, tposZ, tVx, tVy, tVz, orbitPhase, fCyc};
+
     	double vMag = pow(tVx*tVx + tVy*tVy,0.5);
         std::pair<double,double> complexConvolution = GetCavityFIRSample(tKassParticleXP, 0);
-
 
         // The excitation amplitude A_\lambda should be calculated the same way here
         // as in the signal generator.
@@ -447,7 +453,26 @@ namespace locust
 
     }
 
+    double FieldCalculator::calcOrbitPhase(double vx, double vy)
+    {
+    	double phase = 0.;
+        if ((fabs(vy) > 0.))
+    	{
+    		phase = atan(-vx/vy);
+    	}
 
+    	phase += quadrantOrbitCorrection(phase, vx);
+    	return phase;
+    }
+
+    double FieldCalculator::quadrantOrbitCorrection(double phase, double vx)
+    {
+    	double phaseCorrection = 0.;
+    	if (((phase < 0.)&&(vx < 0.)) || ((phase > 0.)&&(vx > 0.)))
+    		phaseCorrection = LMCConst::Pi();
+
+    	return phaseCorrection;
+    }
 
 
 

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -323,19 +323,23 @@ namespace locust
 
     	// l, m, & n are needed for selecting the resonant frequency and Q.  (Still TO-DO).
 
-    	double tposX = aFinalParticle.GetPosition().X();
-    	double tposY = aFinalParticle.GetPosition().Y();
-    	double tposZ = aFinalParticle.GetPosition().Z();
     	double tVx = aFinalParticle.GetVelocity().X();
     	double tVy = aFinalParticle.GetVelocity().Y();
-    	double tVz = aFinalParticle.GetVelocity().Z();
-    	double orbitPhase = calcOrbitPhase(tVx, tVy);
-    	double fCyc = aFinalParticle.GetCyclotronFrequency() * 2. * LMCConst::Pi();
 
-    	std::vector<double> tKassParticleXP = {tposX, tposY, tposZ, tVx, tVy, tVz, orbitPhase, fCyc};
+    	std::vector<double> tKassParticleXP;
+    	tKassParticleXP.push_back(aFinalParticle.GetPosition().X());
+    	tKassParticleXP.push_back(aFinalParticle.GetPosition().Y());
+    	tKassParticleXP.push_back(aFinalParticle.GetPosition().Z());
+    	tKassParticleXP.push_back(aFinalParticle.GetVelocity().X());
+    	tKassParticleXP.push_back(aFinalParticle.GetVelocity().Y());
+    	tKassParticleXP.push_back(aFinalParticle.GetVelocity().Z());
+    	tKassParticleXP.push_back(calcOrbitPhase(tVx, tVy));
+    	tKassParticleXP.push_back(aFinalParticle.GetCyclotronFrequency() * 2. * LMCConst::Pi());
+    	tKassParticleXP.push_back(aFinalParticle.GetTime());
 
     	double vMag = pow(tVx*tVx + tVy*tVy,0.5);
-        std::pair<double,double> complexConvolution = GetCavityFIRSample(tKassParticleXP, 0);
+
+    	std::pair<double,double> complexConvolution = GetCavityFIRSample(tKassParticleXP, 0);
 
         // The excitation amplitude A_\lambda should be calculated the same way here
         // as in the signal generator.

--- a/Source/Kassiopeia/LMCFieldCalculator.hh
+++ b/Source/Kassiopeia/LMCFieldCalculator.hh
@@ -62,6 +62,7 @@ namespace locust
             std::deque<double> fFrequencyBuffer;
             int fNFilterBinsRequired;
             bool fbMultiMode;
+            double fDelaySignalTime;
     };
 
 }

--- a/Source/Kassiopeia/LMCFieldCalculator.hh
+++ b/Source/Kassiopeia/LMCFieldCalculator.hh
@@ -54,6 +54,8 @@ namespace locust
             kl_interface_ptr_t fInterface;
 
         private:
+            double calcOrbitPhase(double vx, double vy);
+            double quadrantOrbitCorrection(double phase, double vx);
             TFReceiverHandler* fTFReceiverHandler;
             AnalyticResponseFunction* fAnalyticResponseFunction;
             std::deque<double> fFIRBuffer;

--- a/Source/Kassiopeia/LMCFieldCalculator.hh
+++ b/Source/Kassiopeia/LMCFieldCalculator.hh
@@ -49,11 +49,13 @@ namespace locust
             int GetNFilterBinsRequired();
             void SetFilterSize( int aFilterSize );
             int GetFilterSize();
+            void SetSignalStartCondition( bool aFlag );
 
 
             kl_interface_ptr_t fInterface;
 
         private:
+            bool GetSignalStartCondition(std::vector<double> tKassParticleXP);
             double calcOrbitPhase(double vx, double vy);
             double quadrantOrbitCorrection(double phase, double vx);
             TFReceiverHandler* fTFReceiverHandler;
@@ -62,7 +64,8 @@ namespace locust
             std::deque<double> fFrequencyBuffer;
             int fNFilterBinsRequired;
             bool fbMultiMode;
-            double fDelaySignalTime;
+            double fZSignalStart;
+            bool fSignalStarted;
     };
 
 }

--- a/Source/Transmitters/LMCKassCurrentTransmitter.cc
+++ b/Source/Transmitters/LMCKassCurrentTransmitter.cc
@@ -121,7 +121,6 @@ namespace locust
 
     	locust::Particle tParticle;
     	std::vector<double> particleXP;
-    	particleXP.resize(9);
 
     	int pSize = fInterface->fParticleHistory.size();
     	if ( pSize > 0 )
@@ -155,15 +154,16 @@ namespace locust
 //            fOrbitPhase += dt*tParticle.GetCyclotronFrequency();  // accumulate phase semi-analytically.
     	    fOrbitPhase = calcOrbitPhase(tvX, tvY); // or use Kass kinematics
 
-            particleXP[0] = pow( tposX*tposX + tposY*tposY, 0.5);
-            particleXP[1] = calcTheta(tposX, tposY);
-            particleXP[2] = tposZ;
-            particleXP[3] = tvX;
-            particleXP[4] = tvY;
-            particleXP[5] = tvZ;
-            particleXP[6] = fOrbitPhase;
-            particleXP[7] = tParticle.GetCyclotronFrequency();
-            particleXP[8] = tParticle.GetLarmorPower();
+            particleXP.push_back(pow( tposX*tposX + tposY*tposY, 0.5));
+            particleXP.push_back(calcTheta(tposX, tposY));
+            particleXP.push_back(tposZ);
+            particleXP.push_back(tvX);
+            particleXP.push_back(tvY);
+            particleXP.push_back(tvZ);
+            particleXP.push_back(fOrbitPhase);
+            particleXP.push_back(tParticle.GetCyclotronFrequency());
+            particleXP.push_back(tParticle.GetLarmorPower());
+            particleXP.push_back(tParticle.GetTime());
 
 
             if (bWaveguide)  // rotate from Kass to Locust coordinate system?


### PR DESCRIPTION
Minor changes to allow a parameterized starting position in z, without impacting the configured pitch angle.  Also a change at the Locust-Kass interface to support more frequent updating in the cavity simulation.  The latter still needs to be checked on the hpc cluster.