### PR TITLE
trigger confirmation

### DIFF
--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -674,6 +674,7 @@ namespace locust
                     std::unique_lock< std::mutex >tLock( fInterface->fMutexDigitizer, std::defer_lock );
                 	if (!fInterface->fKassEventReady)  // Kass confirms event is underway.
                 	{
+                        fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
                         tLock.lock();
                         fInterface->fDigitizerCondition.wait( tLock );
                         if (fInterface->fEventInProgress)
@@ -690,6 +691,8 @@ namespace locust
                     			break;
                     		}
                         }
+                        fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
+
                         tLock.unlock();
                 	}
                  	else  // diagnose Kass

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -209,6 +209,10 @@ namespace locust
         {
             gxml_filename = aParam["xml-filename"]().as_string();
         }
+        if( aParam.has( "trigger-confirm" ) )
+        {
+        	fInterface->fTriggerConfirm = aParam["trigger-confirm"]().as_int();
+        }
 
         // Configure the transmitter, which defines the impulses taken from Kassiopeia.
         if( aParam.has( "transmitter" ))

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -555,7 +555,7 @@ namespace locust
                     if (!fInterface->fKassEventReady)  // Kass confirms event is underway.
                     {
 
-                        fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
+                    	fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
                     	tLock.lock();
 
                     	fInterface->fDigitizerCondition.wait( tLock );

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -551,7 +551,7 @@ namespace locust
                     if (!fInterface->fKassEventReady)  // Kass confirms event is underway.
                     {
 
-
+                        fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
                     	tLock.lock();
 
                     	fInterface->fDigitizerCondition.wait( tLock );
@@ -570,6 +570,7 @@ namespace locust
                     			break;
                     		}
                         }
+                        fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
 
                         tLock.unlock();
 

--- a/Source/Generators/LMCKassSignalGenerator.cc
+++ b/Source/Generators/LMCKassSignalGenerator.cc
@@ -331,6 +331,7 @@ namespace locust
                  std::unique_lock< std::mutex >tLock( fInterface->fMutexDigitizer, std::defer_lock );
              	if (!fInterface->fKassEventReady)  // Kass confirms event is underway.
              	{
+                     fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
                      tLock.lock();
                      fInterface->fDigitizerCondition.wait( tLock );
                      if (fInterface->fEventInProgress)
@@ -347,6 +348,8 @@ namespace locust
                  			break;
                  		}
                      }
+                     fInterface->fSampleIndex = index; // 2-way trigger confirmation for Kass.
+
                      tLock.unlock();
              	}
              	else  // diagnose Kass

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -12,7 +12,6 @@ namespace locust
 			fFieldCalculator( NULL ),
             fPitchAngle( -99. ),
 			fSampleIndex( 0 ),
-			fTriggerConfirm( 100000 ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     	Configure();
@@ -23,7 +22,6 @@ namespace locust
 			fFieldCalculator( NULL ),
             fPitchAngle( aCopy.fPitchAngle ),
 			fSampleIndex( aCopy.fSampleIndex ),
-			fTriggerConfirm( aCopy.fTriggerConfirm ),
             fInterface( aCopy.fInterface )
     {
     	Configure();
@@ -189,8 +187,8 @@ namespace locust
 
                 fInterface->fDigitizerCondition.notify_one();  // notify Locust after writing.
 
-                unsigned tTriggerConfirm = 0;
-                while ((fSampleIndex == fInterface->fSampleIndex) && (tTriggerConfirm < fTriggerConfirm))
+                int tTriggerConfirm = 0;
+                while ((fSampleIndex == fInterface->fSampleIndex) && (tTriggerConfirm < fInterface->fTriggerConfirm))
                 {
                 	// If the Locust sample index has not advanced yet, keep checking it.
                 	tTriggerConfirm += 1;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -9,9 +9,9 @@ namespace locust
 
     CyclotronRadiationExtractor::CyclotronRadiationExtractor() :
             fNewParticleHistory(),
-			fFieldCalculator( NULL ),
+            fFieldCalculator( NULL ),
             fPitchAngle( -99. ),
-			fSampleIndex( 0 ),
+            fSampleIndex( 0 ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     	Configure();
@@ -19,9 +19,9 @@ namespace locust
 
     CyclotronRadiationExtractor::CyclotronRadiationExtractor(const CyclotronRadiationExtractor &aCopy) : KSComponent(),
             fNewParticleHistory(),
-			fFieldCalculator( NULL ),
+            fFieldCalculator( NULL ),
             fPitchAngle( aCopy.fPitchAngle ),
-			fSampleIndex( aCopy.fSampleIndex ),
+            fSampleIndex( aCopy.fSampleIndex ),
             fInterface( aCopy.fInterface )
     {
     	Configure();
@@ -148,7 +148,7 @@ namespace locust
             if (t_poststep - fInterface->fTOld >= fInterface->fKassTimeStep) //take a digitizer sample every KassTimeStep
             {
 
-            	fSampleIndex = fInterface->fSampleIndex; // record Locust sample index before locking:
+                fSampleIndex = fInterface->fSampleIndex; // record Locust sample index before locking
 
                 std::unique_lock< std::mutex >tLock( fInterface->fMutexDigitizer, std::defer_lock );  // lock access to mutex before writing to globals.
                 tLock.lock();

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -50,7 +50,6 @@ namespace locust
             FieldCalculator* fFieldCalculator;
             kl_interface_ptr_t fInterface;
             unsigned fSampleIndex;
-            int fTriggerConfirm;
     };
 
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -8,6 +8,7 @@
 #include "LMCFieldCalculator.hh"
 #include "LMCKassLocustInterface.hh"
 #include "LMCParticle.hh"
+#include "LMCException.hh"
 
 
 #include <deque>
@@ -48,6 +49,8 @@ namespace locust
             double fPitchAngle;
             FieldCalculator* fFieldCalculator;
             kl_interface_ptr_t fInterface;
+            unsigned fSampleIndex;
+            int fTriggerConfirm;
     };
 
 

--- a/Source/Kassiopeia/LMCKassLocustInterface.cc
+++ b/Source/Kassiopeia/LMCKassLocustInterface.cc
@@ -37,8 +37,8 @@ namespace locust
             fConfigureKass( NULL ),
             fBackReaction( true ),
             fbWaveguide( false ),
-			fSampleIndex( 0 ),
-			fTriggerConfirm( 100000 )
+            fSampleIndex( 0 ),
+            fTriggerConfirm( 100000 )
     {}
 
     KLInterfaceBootstrapper::KLInterfaceBootstrapper() :

--- a/Source/Kassiopeia/LMCKassLocustInterface.cc
+++ b/Source/Kassiopeia/LMCKassLocustInterface.cc
@@ -36,8 +36,8 @@ namespace locust
             fField(),
             fConfigureKass( NULL ),
             fBackReaction( true ),
-            fbWaveguide( false )
-
+            fbWaveguide( false ),
+			fSampleIndex( 0 )
     {}
 
     KLInterfaceBootstrapper::KLInterfaceBootstrapper() :

--- a/Source/Kassiopeia/LMCKassLocustInterface.cc
+++ b/Source/Kassiopeia/LMCKassLocustInterface.cc
@@ -37,7 +37,8 @@ namespace locust
             fConfigureKass( NULL ),
             fBackReaction( true ),
             fbWaveguide( false ),
-			fSampleIndex( 0 )
+			fSampleIndex( 0 ),
+			fTriggerConfirm( 100000 )
     {}
 
     KLInterfaceBootstrapper::KLInterfaceBootstrapper() :

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -65,6 +65,7 @@ namespace locust
         // TO-DO:  Move these next two variables into more specific classes.
         bool fBackReaction;
         bool fbWaveguide;
+        unsigned fSampleIndex;
 
 
     };

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -66,6 +66,7 @@ namespace locust
         bool fBackReaction;
         bool fbWaveguide;
         unsigned fSampleIndex;
+        int fTriggerConfirm;
 
 
     };


### PR DESCRIPTION
The issue described in https://github.com/project8/locust_mc/issues/246 motivates the need for a sampling trigger confirmation.  In the description, frequency jitter related to skipped samples is shown without the trigger confirmation.  The problem is substantially reduced when feedback calculations between Locust and Kassiopeia are enabled.  However, recent detailed signal post-processing work has shown that the problem is still infrequently present, even with feedback enabled.  The changes here allow for a configurable check and confirm after each sample.  Tests in the HPC environment are needed before merging.