### PR TITLE
Feature/configurable output path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set( locus_mc_KASS_NPROC "4" CACHE STRING "Number of processors to use for the K
 
 # make the data install directory available as a preprocessor macro
 add_definitions( -DPB_DATA_INSTALL_DIR=${DATA_INSTALL_DIR} )
+add_definitions( -DPB_OUTPUT_DIR=${CMAKE_INSTALL_PREFIX}/output )
 
 set (LOCUST_MC_INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/Source/Generators/

--- a/Source/Applications/Testing/testLMCCavity.cc
+++ b/Source/Applications/Testing/testLMCCavity.cc
@@ -69,7 +69,8 @@ class testCavity_app : public main_app
 			fCavityFrequency(1.067e9),
 			fCavityQ(1000.),
 			fExpandSweep(1.0),
-			fUnitTestOutputFile(false)
+			fUnitTestOutputFile(false),
+			fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
         {
             add_option("-r,--dho-time-resolution", fDHOTimeResolution, "[1.e-8] Time resolution used in Green's function (s).");
             add_option("-m,--dho-threshold-factor", fDHOThresholdFactor, "[0.01] Minimum fractional threshold of Green's function used to calculate FIR.");
@@ -77,6 +78,7 @@ class testCavity_app : public main_app
             add_option("-q,--dho-cavity-Q", fCavityQ, "[1000] Cavity Q.");
             add_option("-x,--expand-sweep", fExpandSweep, "[1.0] Factor by which to expand range of frequency sweep.");
             add_option("-w, --write-output", fUnitTestOutputFile, "[0==false] Write histo to Root file.");
+            add_option("-o, --output-path", fOutputPath, "[PB_OUTPUT_DIR]");
         }
 
         virtual ~testCavity_app() {}
@@ -105,6 +107,10 @@ class testCavity_app : public main_app
         {
         	return fUnitTestOutputFile;
         }
+        std::string GetOutputPath()
+        {
+        	return fOutputPath;
+        }
 
 
     private:
@@ -114,6 +120,7 @@ class testCavity_app : public main_app
         double fCavityQ;
         double fExpandSweep;
         bool fUnitTestOutputFile;
+        std::string fOutputPath;
 };
 
 
@@ -132,6 +139,7 @@ TEST_CASE( "testLMCCavity with default parameter values (pass)", "[single-file]"
 
 	CavityUtility aCavityUtility;
 
+	aCavityUtility.SetOutputPath(the_main.GetOutputPath());
 	aCavityUtility.SetExpandFactor(the_main.GetExpandSweep());
 	aCavityUtility.SetOutputFile(the_main.UnitTestOutputFile());
 	bool checkCavityQ = aCavityUtility.CheckCavityQ( the_main.GetDHOTimeResolution(), the_main.GetDHOThresholdFactor(), the_main.GetCavityFrequency(), the_main.GetCavityQ() );

--- a/Source/Core/LMCHFSSResponseFileHandler.cc
+++ b/Source/Core/LMCHFSSResponseFileHandler.cc
@@ -31,7 +31,8 @@ namespace locust
     fWindowName("tukey"),
     fWindowParam(0.5),
     fPrintFIR ( false ),
-    fConvertStoZ ( false )
+    fConvertStoZ ( false ),
+	fOutputPath( TOSTRING(PB_OUTPUT_DIR))
     {
     }
     
@@ -63,6 +64,10 @@ namespace locust
             LPROG( lmclog, "Characteristic impedance has been changed to " << fCharacteristicImpedance);
         }
 
+    	if ( aParam.has( "output-path" ) )
+    	{
+    		fOutputPath = aParam["output-path"]().as_string();
+    	}
 
         return true;
     }
@@ -294,10 +299,9 @@ namespace locust
 
         if (fPrintFIR)
         {
-            scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
 
-            PrintFIR( fFIRComplex, fFIRNBins, (dataDir / "../output/FIRhisto.root").string() );
-            PrintFIR( fTFComplex, fTFNBins, (dataDir / "../output/TFhisto.root").string() );
+            PrintFIR( fFIRComplex, fFIRNBins, fOutputPath+"/FIRhisto.root");
+            PrintFIR( fTFComplex, fTFNBins, fOutputPath+"/TFhisto.root");
 
             LPROG( lmclog, "Finished writing histos to output/FIRhisto.root and output/TFhisto.root");
             LPROG( lmclog, "Press Return to continue, or Cntrl-C to quit.");
@@ -393,9 +397,8 @@ namespace locust
         if (fPrintFIR)
         {
 
-            scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
-
-            PrintFIR( fFilterComplex, fFIRNBins, (dataDir / "../output/FIRhisto.root").string() );
+        	std::cout << "path is " << fOutputPath << " \n";
+            PrintFIR( fFilterComplex, fFIRNBins, fOutputPath+"/FIRhisto.root");
             LPROG( lmclog, "Finished writing histos to output/FIRhisto.root");
             LPROG( lmclog, "Press Return to continue, or Cntrl-C to quit.");
             getchar();

--- a/Source/Core/LMCHFSSResponseFileHandler.cc
+++ b/Source/Core/LMCHFSSResponseFileHandler.cc
@@ -32,7 +32,7 @@ namespace locust
     fWindowParam(0.5),
     fPrintFIR ( false ),
     fConvertStoZ ( false ),
-	fOutputPath( TOSTRING(PB_OUTPUT_DIR))
+    fOutputPath( TOSTRING(PB_OUTPUT_DIR))
     {
     }
     
@@ -397,7 +397,6 @@ namespace locust
         if (fPrintFIR)
         {
 
-        	std::cout << "path is " << fOutputPath << " \n";
             PrintFIR( fFilterComplex, fFIRNBins, fOutputPath+"/FIRhisto.root");
             LPROG( lmclog, "Finished writing histos to output/FIRhisto.root");
             LPROG( lmclog, "Press Return to continue, or Cntrl-C to quit.");

--- a/Source/Core/LMCHFSSResponseFileHandler.hh
+++ b/Source/Core/LMCHFSSResponseFileHandler.hh
@@ -59,6 +59,8 @@ namespace locust
         double fWindowParam;
         bool fPrintFIR;
         bool fConvertStoZ;
+        std::string fOutputPath;
+
 #ifdef ROOT_FOUND
         FileWriter* fRootHistoWriter;
 #endif

--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -403,9 +403,8 @@ namespace locust
     	//  Write trajectory points, dot product, and E-field mag to file for debugging etc.
     	if (IntermediateFile)
     	{
-            scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
             char buffer[60];
-            int a = sprintf(buffer, "%s/../output/dotProducts.txt", dataDir.string().c_str());
+            int a = sprintf(buffer, "%s/dotProducts.txt", GetOutputPath().c_str());
             const char *fpname = buffer;
             FILE *fp = fopen(fpname, "a");
             fprintf(fp, "%g %g %g %g\n", tKassParticleXP[0], tKassParticleXP[1], unitJdotE, tEmag);
@@ -487,8 +486,7 @@ namespace locust
 
     void CylindricalCavity::PrintModeMaps(int nModes, double zSlice, double thetaSlice)
     {
-    	scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
-        std::string sFileName = (dataDir / "../output/ModemapOutput.root").string();
+        std::string sFileName = GetOutputPath()+"/ModemapOutput.root";
 
 #ifdef ROOT_FOUND
 
@@ -614,8 +612,7 @@ namespace locust
 
     void CylindricalCavity::PrintModeMapsLongSlice(int nModes, double thetaSlice)
     {
-    	scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
-        std::string sFileName = (dataDir / "../output/ModemapOutput.root").string();
+        std::string sFileName = GetOutputPath()+"/ModemapOutput.root";
 
 #ifdef ROOT_FOUND
 

--- a/Source/Fields/LMCField.cc
+++ b/Source/Fields/LMCField.cc
@@ -23,7 +23,7 @@ namespace locust
         fCENTER_TO_SHORT( 0.05 ),
         fCENTER_TO_ANTENNA( 0.05 ),
         fPlotModeMaps( false ),
-		fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
+        fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
     {}
     Field::~Field() {}
 

--- a/Source/Fields/LMCField.cc
+++ b/Source/Fields/LMCField.cc
@@ -22,7 +22,8 @@ namespace locust
         fY( 0.004318 ),
         fCENTER_TO_SHORT( 0.05 ),
         fCENTER_TO_ANTENNA( 0.05 ),
-        fPlotModeMaps( false )
+        fPlotModeMaps( false ),
+		fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
     {}
     Field::~Field() {}
 
@@ -48,6 +49,11 @@ namespace locust
     	if( aParam.has( "plot-mode-maps" ) )
     	{
     		SetPlotModeMaps(aParam["plot-mode-maps"]().as_bool());
+    	}
+
+    	if ( aParam.has( "output-path" ) )
+    	{
+    		fOutputPath = aParam["output-path"]().as_string();
     	}
 
     	fAvgDotProductFactor.resize(fNModes);
@@ -248,6 +254,15 @@ namespace locust
     	fPlotModeMaps = aFlag;
     }
 
+    std::string Field::GetOutputPath()
+    {
+        return fOutputPath;
+    }
+
+    void Field::SetOutputPath( std::string aPath )
+    {
+     	fOutputPath = aPath;
+    }
 
 
 } /* namespace locust */

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -121,6 +121,8 @@ namespace locust
             void SetCenterToAntenna( double aDistance );
             bool PlotModeMaps() const;
             void SetPlotModeMaps( bool aFlag );
+            void SetOutputPath( std::string aPath );
+            std::string GetOutputPath();
 
 
 
@@ -138,6 +140,7 @@ namespace locust
             double fCENTER_TO_ANTENNA;
             std::vector<std::vector<std::vector<double>>> fAvgDotProductFactor;
             bool fPlotModeMaps;
+            std::string fOutputPath;
 
     };
 

--- a/Source/Fields/LMCRectangularWaveguide.cc
+++ b/Source/Fields/LMCRectangularWaveguide.cc
@@ -266,9 +266,8 @@ namespace locust
     	//  Write trajectory points, dot product, and E-field mag to file for debugging etc.
     	if (IntermediateFile)
     	{
-            scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
             char cBufferFileName[60];
-            int a = sprintf(cBufferFileName, "%s/../output/dotProducts.txt", dataDir.string().c_str());
+            int a = sprintf(cBufferFileName, "%s/dotProducts.txt", GetOutputPath().c_str());
             const char *fpname = cBufferFileName;
             FILE *fp = fopen(fpname, "a");
             fprintf(fp, "%g %g %g %g\n", tKassParticleXP[0], tKassParticleXP[1], unitJdotE, tEmag);
@@ -400,8 +399,7 @@ namespace locust
 
     void RectangularWaveguide::PrintModeMaps(int nModes, double zSlice, double thetaSlice)
     {
-        scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
-        std::string sFileName = (dataDir / "../output/ModemapOutput.root").string();
+        std::string sFileName = GetOutputPath()+"/ModemapOutput.root";
         bool bTE = 1; // TE and not TM.
 
 #ifdef ROOT_FOUND

--- a/Source/Generators/LMCTestSignalGenerator.cc
+++ b/Source/Generators/LMCTestSignalGenerator.cc
@@ -30,7 +30,8 @@ namespace locust
         fAmplitude( 5.e-8 ),
         fMixingProduct( false ),
         fWriteRootHisto( false ),
-        fWriteRootGraph( false )
+        fWriteRootGraph( false ),
+		fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
     {
         fRequiredSignalState = Signal::kTime;
     }
@@ -78,6 +79,11 @@ namespace locust
         {
         	fWriteRootGraph = aParam.get_value< bool >( "write-root-graph", fWriteRootGraph );
         }
+
+    	if ( aParam.has( "output-path" ) )
+    	{
+    		fOutputPath = aParam["output-path"]().as_string();
+    	}
 
         if( aParam.has( "domain" ) )
         {
@@ -207,9 +213,8 @@ namespace locust
     {
 		#ifdef ROOT_FOUND
 
-    	scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
     	char cBufferFileName[60];
-    	int a = sprintf(cBufferFileName, "%s/../output/TestSignalHisto.root", dataDir.string().c_str());
+    	int a = sprintf(cBufferFileName, "%s/TestSignalHisto.root", fOutputPath.c_str());
     	const char *cFileName = cBufferFileName;
 
     	FileWriter* aRootHistoWriter = RootHistoWriter::get_instance();
@@ -230,9 +235,8 @@ namespace locust
     {
 		#ifdef ROOT_FOUND
 
-    	scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
     	char cBufferFileName[60];
-    	int a = sprintf(cBufferFileName, "%s/../output/TestSignalGraph.root", dataDir.string().c_str());
+    	int a = sprintf(cBufferFileName, "%s/TestSignalGraph.root", fOutputPath.c_str());
     	const char *cFileName = cBufferFileName;
     	FileWriter* aRootGraphWriter = RootGraphWriter::get_instance();
     	aRootGraphWriter->SetFilename(cFileName);

--- a/Source/Generators/LMCTestSignalGenerator.cc
+++ b/Source/Generators/LMCTestSignalGenerator.cc
@@ -31,7 +31,7 @@ namespace locust
         fMixingProduct( false ),
         fWriteRootHisto( false ),
         fWriteRootGraph( false ),
-		fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
+        fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
     {
         fRequiredSignalState = Signal::kTime;
     }

--- a/Source/Generators/LMCTestSignalGenerator.hh
+++ b/Source/Generators/LMCTestSignalGenerator.hh
@@ -117,6 +117,7 @@ namespace locust
             bool fMixingProduct;
             bool fWriteRootHisto;
             bool fWriteRootGraph;
+            std::string fOutputPath;
 
             
     };

--- a/Source/RxComponents/LMCCavityModes.cc
+++ b/Source/RxComponents/LMCCavityModes.cc
@@ -100,13 +100,8 @@ namespace locust
 
 	bool CavityModes::AddOneModeToCavityProbe(int l, int m, int n, Signal* aSignal, std::vector<double> particleXP, double excitationAmplitude, double EFieldAtProbe, std::vector<double> cavityDopplerFrequency, double dt, double phi_LO, double totalScalingFactor, unsigned sampleIndex, int channelIndex, bool initParticle)
 	{
-		double trapShift = 0.;
-		if (particleXP[5] > 0.) trapShift = -LMCConst::Pi()*0.01;
-		else trapShift = 0.; //-LMCConst::Pi()*0.01;
-
 		double dopplerFrequency = cavityDopplerFrequency[0];  // Only one shift, unlike in waveguide.
-		SetVoltagePhase( trapShift + GetVoltagePhase(channelIndex, l, m, n) + dopplerFrequency * dt, channelIndex, l, m, n ) ;
-//		SetVoltagePhase( GetVoltagePhase(channelIndex, l, m, n) + dopplerFrequency * dt, channelIndex, l, m, n ) ;
+		SetVoltagePhase( GetVoltagePhase(channelIndex, l, m, n) + dopplerFrequency * dt, channelIndex, l, m, n ) ;
 		double voltageValue = excitationAmplitude * EFieldAtProbe;
 		voltageValue *= cos(GetVoltagePhase(channelIndex, l, m, n));
 

--- a/Source/RxComponents/LMCCavityModes.cc
+++ b/Source/RxComponents/LMCCavityModes.cc
@@ -43,9 +43,8 @@ namespace locust
 
         if( aParam.has( "norm-check" ) )
         {
-            scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
-            std::string sFileName = (dataDir / "../output/ModeEnergies.root").string();
-            std::string sTextFileName = (dataDir / "../output/ModeEnergies.txt").string();
+            std::string sFileName = GetOutputPath()+"/ModeEnergies.root";
+            std::string sTextFileName = GetOutputPath()+"/ModeEnergies.txt";
             fp = fopen(sTextFileName.c_str(), "w");
             fclose(fp);
 
@@ -101,8 +100,13 @@ namespace locust
 
 	bool CavityModes::AddOneModeToCavityProbe(int l, int m, int n, Signal* aSignal, std::vector<double> particleXP, double excitationAmplitude, double EFieldAtProbe, std::vector<double> cavityDopplerFrequency, double dt, double phi_LO, double totalScalingFactor, unsigned sampleIndex, int channelIndex, bool initParticle)
 	{
+		double trapShift = 0.;
+		if (particleXP[5] > 0.) trapShift = -LMCConst::Pi()*0.01;
+		else trapShift = 0.; //-LMCConst::Pi()*0.01;
+
 		double dopplerFrequency = cavityDopplerFrequency[0];  // Only one shift, unlike in waveguide.
-		SetVoltagePhase( GetVoltagePhase(channelIndex, l, m, n) + dopplerFrequency * dt, channelIndex, l, m, n ) ;
+		SetVoltagePhase( trapShift + GetVoltagePhase(channelIndex, l, m, n) + dopplerFrequency * dt, channelIndex, l, m, n ) ;
+//		SetVoltagePhase( GetVoltagePhase(channelIndex, l, m, n) + dopplerFrequency * dt, channelIndex, l, m, n ) ;
 		double voltageValue = excitationAmplitude * EFieldAtProbe;
 		voltageValue *= cos(GetVoltagePhase(channelIndex, l, m, n));
 
@@ -151,9 +155,8 @@ namespace locust
 
 	bool CavityModes::AddOneSampleToRollingAvg(int l, int m, int n, double excitationAmplitude, unsigned sampleIndex)
 	{
-	    scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
 	    char cBufferFileName[60];
-	    int a = sprintf(cBufferFileName, "%s/../output/ModeEnergies.txt", dataDir.string().c_str());
+	    int a = sprintf(cBufferFileName, "%s/ModeEnergies.txt", GetOutputPath().c_str());
 	    const char *cFileName = cBufferFileName;
 	    fp = fopen(cFileName, "a");
 

--- a/Source/RxComponents/LMCCavityModes.hh
+++ b/Source/RxComponents/LMCCavityModes.hh
@@ -51,7 +51,6 @@ namespace locust
 
         private:
             double fOrbitPhase;
-            double fTrapPhase;
             std::vector<std::vector<std::vector<std::vector<double>>>> fVoltagePhase;
             std::vector<std::vector<std::vector<double>>> fRollingAvg;
             std::vector<std::vector<std::vector<int>>> fCounter;

--- a/Source/RxComponents/LMCCavityModes.hh
+++ b/Source/RxComponents/LMCCavityModes.hh
@@ -51,6 +51,7 @@ namespace locust
 
         private:
             double fOrbitPhase;
+            double fTrapPhase;
             std::vector<std::vector<std::vector<std::vector<double>>>> fVoltagePhase;
             std::vector<std::vector<std::vector<double>>> fRollingAvg;
             std::vector<std::vector<std::vector<int>>> fCounter;

--- a/Source/RxComponents/LMCPowerCombiner.cc
+++ b/Source/RxComponents/LMCPowerCombiner.cc
@@ -26,16 +26,23 @@ namespace locust
 			fvoltageCheck( false ),
 			fNCavityModes( 0 ),
 			fNChannels( 1 ),
-			fWaveguideShortIsPresent( true )
+			fWaveguideShortIsPresent( true ),
+			fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
     {}
     PowerCombiner::~PowerCombiner() {}
 
 
     bool PowerCombiner::Configure( const scarab::param_node& aParam )
     {
+
     	if ( aParam.has( "voltage-check" ) )
     	{
     		fvoltageCheck = aParam["voltage-check"]().as_bool();
+    	}
+
+    	if ( aParam.has( "output-path" ) )
+    	{
+    		fOutputPath = aParam["output-path"]().as_string();
     	}
 
         if( aParam.has( "nelements-per-strip" ) )
@@ -161,6 +168,15 @@ namespace locust
     void PowerCombiner::SetNChannels( int aNumberOfChannels )
     {
      	fNChannels = aNumberOfChannels;
+    }
+
+    std::string PowerCombiner::GetOutputPath()
+    {
+        return fOutputPath;
+    }
+    void PowerCombiner::SetOutputPath( std::string aPath )
+    {
+     	fOutputPath = aPath;
     }
 
     bool PowerCombiner::GetWaveguideShortIsPresent()

--- a/Source/RxComponents/LMCPowerCombiner.hh
+++ b/Source/RxComponents/LMCPowerCombiner.hh
@@ -66,6 +66,8 @@ namespace locust
             int GetNCavityModes();
             void SetNChannels( int aNumberOfChannels );
             int GetNChannels();
+            void SetOutputPath( std::string aPath );
+            std::string GetOutputPath();
             double GetVoltagePhase();
             void SetVoltagePhase( double aPhase );
             virtual bool SizeNChannels(int aNumberOfChannels) {return true;};
@@ -86,6 +88,7 @@ namespace locust
             bool fvoltageCheck;
             int fNCavityModes;
             int fNChannels;
+            std::string fOutputPath;
             bool fWaveguideShortIsPresent;
 
 

--- a/Source/Utilities/LMCCavityUtility.cc
+++ b/Source/Utilities/LMCCavityUtility.cc
@@ -21,7 +21,8 @@ namespace locust
 			fWriteOutputFile( false ),
 			fTFReceiverHandler( 0 ),
 			fAnalyticResponseFunction( 0 ),
-			fparam_0( new param_node() )
+			fparam_0( new param_node() ),
+			fOutputPath( TOSTRING(PB_OUTPUT_DIR) )
     {
     }
 
@@ -106,12 +107,17 @@ namespace locust
 	    return incidentSignal;
 	}
 
+
+	void CavityUtility::SetOutputPath( std::string aPath )
+	{
+		fOutputPath = aPath;
+	}
+
 	bool CavityUtility::WriteRootHisto(int npoints, double* freqArray, double* gainArray)
 	{
 	#ifdef ROOT_FOUND
-		scarab::path dataDir = TOSTRING(PB_DATA_INSTALL_DIR);
 		char cBufferFileName[60];
-		int n = sprintf(cBufferFileName, "%s/../output/UnitTestOutput.root", dataDir.string().c_str());
+		int n = sprintf(cBufferFileName, "%s/UnitTestOutput.root", fOutputPath.c_str());
 		const char *cFileName = cBufferFileName;
 		FileWriter* aRootHistoWriter = RootHistoWriter::get_instance();
 		aRootHistoWriter->SetFilename(cFileName);

--- a/Source/Utilities/LMCCavityUtility.hh
+++ b/Source/Utilities/LMCCavityUtility.hh
@@ -51,6 +51,7 @@ namespace locust
         bool WriteRootHisto(int npoints, double* freqArray, double* gainArray);
         bool PopulateSignal(Signal* aSignal, int N0);
         const scarab::param_node* GetParams();
+        void SetOutputPath( std::string aPath );
 
 
     private:
@@ -63,6 +64,7 @@ namespace locust
         double fFilterRate;
         double fExpandFactor;
         bool fWriteOutputFile;
+        std::string fOutputPath;
 
 
     };


### PR DESCRIPTION
These changes allow for an output path defined by default in cmake, but that is still configurable by command-line parameter.  This provides flexibility when writing intermediate outputs in a container environment that may have write restrictions.  It also provides correct output paths when compiling source code that is mounted from an arbitrary location external to the container.  