### PR TITLE
2-way trigger.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/catchNodeInKass]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/catchNodeInKass]
     tags: ['*']
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 2.6.1)
+project( locust_mc VERSION 2.6.2)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Core/LMCGenerator.cc
+++ b/Source/Core/LMCGenerator.cc
@@ -83,6 +83,11 @@ namespace locust
         fNChannels = nchannels;
     }
 
+    void Generator::ConfigureRecordLength( unsigned recordLength ) const
+    {
+        fRecordLength = recordLength;
+    }
+
     void Generator::ConfigureAcquisitionRate( double ar ) const
     {
         fAcquisitionRate = ar;

--- a/Source/Core/LMCGenerator.hh
+++ b/Source/Core/LMCGenerator.hh
@@ -27,6 +27,7 @@ namespace locust
 
             virtual bool Configure( const scarab::param_node& aNode ) = 0;
             void ConfigureNChannels( unsigned nchannels ) const;
+            void ConfigureRecordLength( unsigned recordLength ) const;
             void ConfigureAcquisitionRate( double ar ) const;
 
             virtual void Accept( GeneratorVisitor* aVisitor ) const = 0;
@@ -52,6 +53,7 @@ namespace locust
             virtual bool DoGenerate( Signal* aSignal ) = 0;
             mutable unsigned fNChannels;
             mutable double fAcquisitionRate;
+            mutable unsigned fRecordLength;
 
 
             std::string fName;

--- a/Source/Core/LMCRunLengthCalculator.cc
+++ b/Source/Core/LMCRunLengthCalculator.cc
@@ -74,6 +74,7 @@ namespace locust
         while( nextGenerator != NULL )
         {
 	    nextGenerator->ConfigureNChannels(frlcChannels);
+	    nextGenerator->ConfigureRecordLength(fRecordSize);
 	    nextGenerator->ConfigureAcquisitionRate(frlcAcquisitionRate);
             nextGenerator->Accept( this );
             nextGenerator = nextGenerator->GetNextGenerator();

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -50,7 +50,7 @@ namespace locust
     }
 
 
-    bool CavitySignalGenerator::ConfigureInterface()
+    bool CavitySignalGenerator::ConfigureInterface( Signal* aSignal )
     {
 
     	if ( fInterface == nullptr ) fInterface.reset( new KassLocustInterface() );
@@ -212,6 +212,7 @@ namespace locust
         {
         	fInterface->fTriggerConfirm = tParam["trigger-confirm"]().as_int();
         }
+        fInterface->fFastRecordLength = fRecordLength * aSignal->DecimationFactor();
 
         // Configure Locust-Kass interface classes and parameters:
         fFieldCalculator = new FieldCalculator();
@@ -562,7 +563,8 @@ namespace locust
 
     bool CavitySignalGenerator::DoGenerateTime( Signal* aSignal )
     {
-        ConfigureInterface();
+        ConfigureInterface( aSignal );
+
         if (fRandomPreEventSamples) RandomizeStartDelay();
 
         fPowerCombiner->SizeNChannels(fNChannels);

--- a/Source/Generators/LMCCavitySignalGenerator.hh
+++ b/Source/Generators/LMCCavitySignalGenerator.hh
@@ -72,7 +72,7 @@ namespace locust
             virtual ~CavitySignalGenerator();
 
             bool Configure( const scarab::param_node& aNode );
-            bool ConfigureInterface();
+            bool ConfigureInterface(Signal* aSignal);
             bool CrossCheckCavityConfig();
             bool CrossCheckAliasing(Signal* aSignal, double dopplerFrequency );
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -53,6 +53,7 @@ namespace locust
     }
 
 
+
     locust::Particle CyclotronRadiationExtractor::ExtractKassiopeiaParticle( Kassiopeia::KSParticle &anInitialParticle, Kassiopeia::KSParticle &aFinalParticle)
     {
         LMCThreeVector tPosition(aFinalParticle.GetPosition().Components());
@@ -192,7 +193,19 @@ namespace locust
                 {
                 	// If the Locust sample index has not advanced yet, keep checking it.
                 	tTriggerConfirm += 1;
+                	if ( tTriggerConfirm > fInterface->fTriggerConfirm - 3)
+                	{
+                 	    LERROR(lmclog,"Locust digitizer sample index has not advanced properly.  "
+                 	    		"Either increase the value of \"trigger-confirm\" [10000] and resubmit "
+                 	    		"the jobs, or check HPC status.");
+
+                 	    exit(-1);  // This works, but is not really preferable.
+//                    	throw 3; // This is the preferred approach, but is not being caught by LocustSim.cc,
+                 	             // and is causing an "unhandled exception" error.
+
+                	}
                 }
+
 
             }
         } // DoneWithSignalGeneration

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -196,7 +196,7 @@ namespace locust
                 	if ( tTriggerConfirm > fInterface->fTriggerConfirm - 3)
                 	{
                  	    LERROR(lmclog,"Locust digitizer sample index has not advanced properly.  "
-                 	    		"Either increase the value of \"trigger-confirm\" [10000] and resubmit "
+                 	    		"Either increase the value of \"trigger-confirm\" [100000] and resubmit "
                  	    		"the jobs, or check HPC status.");
 
                  	    exit(-1);  // This works, but is not really preferable.

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -195,11 +195,11 @@ namespace locust
                 {
                 	// If the Locust sample index has not advanced yet, keep checking it.
                     tTriggerConfirm += 1;
-                    LPROG(lmclog,"tTriggerConfirm index = " << tTriggerConfirm);
                     if ( ( tTriggerConfirm > fInterface->fTriggerConfirm - 3) && ( fSampleIndex < fInterface->fFastRecordLength ) )
                     {
                         LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm);
                         LPROG(lmclog,"Checking the digitizer synchronization, at fast sample = " << fSampleIndex);
+                        LPROG(lmclog,"Fast record length = " << fInterface->fFastRecordLength);
                         std::this_thread::sleep_for(std::chrono::milliseconds(10000));
                         if ( !(fSampleIndex < fInterface->fSampleIndex) )
                         {

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -195,9 +195,11 @@ namespace locust
                 {
                 	// If the Locust sample index has not advanced yet, keep checking it.
                     tTriggerConfirm += 1;
+                    LPROG(lmclog,"tTriggerConfirm index = " << tTriggerConfirm);
                     if ( ( tTriggerConfirm > fInterface->fTriggerConfirm - 3) && ( fSampleIndex < fInterface->fFastRecordLength ) )
                     {
-                        LPROG(lmclog,"Checking the digitizer synchronization, at fast sample  " << fSampleIndex);
+                        LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm);
+                        LPROG(lmclog,"Checking the digitizer synchronization, at fast sample = " << fSampleIndex);
                         std::this_thread::sleep_for(std::chrono::milliseconds(10000));
                         if ( !(fSampleIndex < fInterface->fSampleIndex) )
                         {

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -199,17 +199,16 @@ namespace locust
                     {
                         LPROG(lmclog,"Checking the digitizer synchronization, at fast sample  " << fSampleIndex);
                         std::this_thread::sleep_for(std::chrono::milliseconds(10000));
-                        if ( (fSampleIndex > fInterface->fSampleIndex) )
+                        if ( !(fSampleIndex < fInterface->fSampleIndex) )
                         {
                             LPROG(lmclog,"Checking the digitizer synchronization again.  ");
                             std::this_thread::sleep_for(std::chrono::milliseconds(10000));
-                            if ( (fSampleIndex > fInterface->fSampleIndex) )
+                            if ( !(fSampleIndex < fInterface->fSampleIndex) )
                             {
                                 LERROR(lmclog,"Locust digitizer sample index has not advanced properly.  "
-                         	    		"Either increase the value of \"trigger-confirm\" [100000] and resubmit "
-                         	    		"the jobs, or check HPC status.");
+                         	    		"Please either resubmit the job, or check HPC status.");
                                 LERROR(lmclog, "tTriggerConfirm, fSampleIndex are " << tTriggerConfirm << " and " << fSampleIndex);
-                                exit(-1);  // To-do:  throw this exception to scarab.
+                                exit(-1);  // TO-DO:  throw this exception to be caught properly by scarab, as in LocustSim.cc .
                             }
                         }
                     }

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -191,14 +191,22 @@ namespace locust
                 fInterface->fDigitizerCondition.notify_one();  // notify Locust after writing.
 
                 int tTriggerConfirm = 0;
+
                 while ( !(fSampleIndex < fInterface->fSampleIndex) && (tTriggerConfirm < fInterface->fTriggerConfirm) )
                 {
-                	// If the Locust sample index has not advanced yet, keep checking it.
+                    // If the Locust sample index has not advanced yet, keep checking it.
                     tTriggerConfirm += 1;
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    if ( tTriggerConfirm % 1000 == 0 )
+                    {
+                    	LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm );
+                    }
+
                     if ( ( tTriggerConfirm > fInterface->fTriggerConfirm - 3) && ( fSampleIndex < fInterface->fFastRecordLength ) )
                     {
                         LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm);
                         LPROG(lmclog,"Checking the digitizer synchronization, at fast sample = " << fSampleIndex);
+                        LPROG(lmclog,"Checking the digitizer synchronization, at Locust fast sample = " << fInterface->fSampleIndex);
                         LPROG(lmclog,"Fast record length = " << fInterface->fFastRecordLength);
                         std::this_thread::sleep_for(std::chrono::milliseconds(10000));
                         if ( !(fSampleIndex < fInterface->fSampleIndex) )

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -191,7 +191,7 @@ namespace locust
                 fInterface->fDigitizerCondition.notify_one();  // notify Locust after writing.
 
                 int tTriggerConfirm = 0;
-                while ((fSampleIndex == fInterface->fSampleIndex) && (tTriggerConfirm < fInterface->fTriggerConfirm))
+                while ( !(fSampleIndex < fInterface->fSampleIndex) && (tTriggerConfirm < fInterface->fTriggerConfirm) )
                 {
                 	// If the Locust sample index has not advanced yet, keep checking it.
                     tTriggerConfirm += 1;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -193,11 +193,13 @@ namespace locust
                 {
                 	// If the Locust sample index has not advanced yet, keep checking it.
                 	tTriggerConfirm += 1;
-                	if ( tTriggerConfirm > fInterface->fTriggerConfirm - 3)
+                	if ( ( tTriggerConfirm > fInterface->fTriggerConfirm - 3) && ( fSampleIndex < fInterface->fFastRecordLength ) )
                 	{
                  	    LERROR(lmclog,"Locust digitizer sample index has not advanced properly.  "
                  	    		"Either increase the value of \"trigger-confirm\" [100000] and resubmit "
                  	    		"the jobs, or check HPC status.");
+                 	    LERROR(lmclog, "tTriggerConfirm, fSampleIndex are " << tTriggerConfirm << " and " << fSampleIndex);
+
 
                  	    exit(-1);  // This works, but is not really preferable.
 //                    	throw 3; // This is the preferred approach, but is not being caught by LocustSim.cc,

--- a/Source/Kassiopeia/LMCKassLocustInterface.cc
+++ b/Source/Kassiopeia/LMCKassLocustInterface.cc
@@ -38,7 +38,8 @@ namespace locust
             fBackReaction( true ),
             fbWaveguide( false ),
             fSampleIndex( 0 ),
-            fTriggerConfirm( 100000 )
+            fTriggerConfirm( 100000 ),
+            fFastRecordLength( 0 )
     {}
 
     KLInterfaceBootstrapper::KLInterfaceBootstrapper() :

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -67,6 +67,7 @@ namespace locust
         bool fbWaveguide;
         unsigned fSampleIndex;
         int fTriggerConfirm;
+        int fFastRecordLength;
 
 
     };


### PR DESCRIPTION
These changes provide a 2-way sampling confirmation between Locust and Kassiopeia that is useful when running in a fluctuating computing environment.  If the synchronization can't be maintained, the run stops.  This provides an additional layer of mitigation against https://github.com/project8/locust_mc/issues/246 .  Performance appears to be relatively unchanged.