### PR TITLE
record event properties and run parameters

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/randomize]
+    branches: [master, develop, feature/truthWriting]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/truthWriting]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 2.6.2)
+project( locust_mc VERSION 2.7.0)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -48,103 +48,117 @@ namespace locust
 		fKassNeverStarted( false ),
 		fSkippedSamples( false ),
 		fAllowFastSampling( false ),
-		fInterface( new KassLocustInterface() )
+		fInterface( nullptr )  // Initialize fInterface to (nullptr) instead of to (new KassLocustInterface())
     {
         fRequiredSignalState = Signal::kTime;
-
-        KLInterfaceBootstrapper::get_instance()->SetInterface( fInterface );
     }
 
     ArraySignalGenerator::~ArraySignalGenerator()
     {
     }
 
-    bool ArraySignalGenerator::Configure( const scarab::param_node& aParam )
+    void ArraySignalGenerator::SetParameters( const scarab::param_node& aParam )
+    {
+    	fParam = &aParam;
+    }
+
+
+    const scarab::param_node* ArraySignalGenerator::GetParameters()
+    {
+    	return fParam;
+    }
+
+    bool ArraySignalGenerator::ConfigureInterface( Signal* aSignal )
     {
 
-    	if (aParam.has( "power-combining-feed" ))
+        if ( fInterface == nullptr ) fInterface.reset( new KassLocustInterface() );
+        KLInterfaceBootstrapper::get_instance()->SetInterface( fInterface );
+
+        const scarab::param_node& tParam = *GetParameters();
+
+    	if (tParam.has( "power-combining-feed" ))
     	{
     		int npowercombiners = 0;
 
-        	if(aParam["power-combining-feed"]().as_string() == "voltage-divider")
+        	if(tParam["power-combining-feed"]().as_string() == "voltage-divider")
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new VoltageDivider;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring voltage divider.");
         			exit(-1);
         		}
         		fAntennaElementPositioner = new AntennaElementPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring antenna element positioner.");
             		exit(-1);
             	}
         	}
 
-        	if(aParam["power-combining-feed"]().as_string() == "slotted-waveguide")
+        	if(tParam["power-combining-feed"]().as_string() == "slotted-waveguide")
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new SlottedWaveguide;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring slotted waveguide.");
         			exit(-1);
         		}
         		fAntennaElementPositioner = new AntennaElementPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring antenna element positioner.");
             		exit(-1);
             	}
         	}
 
-        	if(aParam["power-combining-feed"]().as_string() == "single-patch")
+        	if(tParam["power-combining-feed"]().as_string() == "single-patch")
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new SinglePatch;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring single patch.");
         			exit(-1);
         		}
         		fAntennaElementPositioner = new SinglePatchPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring single patch positioner.");
             		exit(-1);
             	}
         	}
 
-        	if(aParam["power-combining-feed"]().as_string() == "corporate")
+        	if(tParam["power-combining-feed"]().as_string() == "corporate")
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new CorporateFeed;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring corporate feed.");
         			exit(-1);
         		}
         		fAntennaElementPositioner = new AntennaElementPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring antenna element positioner.");
             		exit(-1);
             	}
         	}
 
-        	if(aParam["power-combining-feed"]().as_string() == "s-matrix")
+        	if(tParam["power-combining-feed"]().as_string() == "s-matrix")
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new SMatrix;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring s matrix.");
         			exit(-1);
         		}
         		fAntennaElementPositioner = new AntennaElementPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring antenna element positioner.");
             		exit(-1);
@@ -152,19 +166,19 @@ namespace locust
         	}
 
 
-        	if((aParam["power-combining-feed"]().as_string() == "unit-cell-one-quarter")||
-               (aParam["power-combining-feed"]().as_string() == "unit-cell-seven-eighths")||
-               (aParam["power-combining-feed"]().as_string() == "unit-cell-nine-sixteenths"))
+        	if((tParam["power-combining-feed"]().as_string() == "unit-cell-one-quarter")||
+               (tParam["power-combining-feed"]().as_string() == "unit-cell-seven-eighths")||
+               (tParam["power-combining-feed"]().as_string() == "unit-cell-nine-sixteenths"))
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new UnitCell;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring unit cell.");
         			exit(-1);
         		}
         		fAntennaElementPositioner = new AntennaElementPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring antenna element positioner.");
             		exit(-1);
@@ -172,16 +186,16 @@ namespace locust
         	}
 
 
-        	if(aParam["power-combining-feed"]().as_string() == "series-feed")
+        	if(tParam["power-combining-feed"]().as_string() == "series-feed")
         	{
         		npowercombiners += 1;
         		fPowerCombiner = new SeriesFeed;
-        		if(!fPowerCombiner->Configure(aParam))
+        		if(!fPowerCombiner->Configure(tParam))
         		{
         			LERROR(lmclog,"Error configuring series feed.");
         		}
         		fAntennaElementPositioner = new AntennaElementPositioner;
-           		if(!fAntennaElementPositioner->Configure(aParam))
+           		if(!fAntennaElementPositioner->Configure(tParam))
             	{
             		LERROR(lmclog,"Error configuring antenna element positioner.");
             		exit(-1);
@@ -203,15 +217,15 @@ namespace locust
         }
 
 
-        if( aParam.has( "transmitter" ))
+        if( tParam.has( "transmitter" ))
         {
         	int ntransmitters = 0;
 
-        	if(aParam["transmitter"]().as_string() == "antenna")
+        	if(tParam["transmitter"]().as_string() == "antenna")
         	{
         		ntransmitters += 1;
         		fTransmitter = new AntennaSignalTransmitter;
-        		if(!fTransmitter->Configure(aParam))
+        		if(!fTransmitter->Configure(tParam))
         		{
         			LERROR(lmclog,"Error Configuring antenna signal transmitter class");
         		}
@@ -221,22 +235,22 @@ namespace locust
         		}
         	}
 
-        	if(aParam["transmitter"]().as_string() == "planewave")
+        	if(tParam["transmitter"]().as_string() == "planewave")
         	{
         		ntransmitters += 1;
         		fTransmitter = new PlaneWaveTransmitter;
-        		if(!fTransmitter->Configure(aParam))
+        		if(!fTransmitter->Configure(tParam))
         		{
         			LERROR(lmclog,"Error Configuring planewave transmitter class");
         		}
 
         	}
 
-        	if(aParam["transmitter"]().as_string() == "kassiopeia")
+        	if(tParam["transmitter"]().as_string() == "kassiopeia")
         	{
         		ntransmitters += 1;
         		fTransmitter = new KassTransmitter;
-        		if(!fTransmitter->Configure(aParam))
+        		if(!fTransmitter->Configure(tParam))
         		{
         			LERROR(lmclog,"Error Configuring kassiopeia transmitter class");
         		}
@@ -256,21 +270,39 @@ namespace locust
         }
 
 
-    	if(!fTFReceiverHandler.Configure(aParam))
+    	if(!fTFReceiverHandler.Configure(tParam))
     	{
     		LERROR(lmclog,"Error configuring receiver FIRHandler class");
     	}
 
-        if( aParam.has( "buffer-size" ) )
+        if( tParam.has( "buffer-size" ) )
         {
-        	fFieldBufferSize = aParam["buffer-size"]().as_int();
-        	fHilbertTransform.SetBufferSize(aParam["buffer-size"]().as_int());
+        	fFieldBufferSize = tParam["buffer-size"]().as_int();
+        	fHilbertTransform.SetBufferSize(tParam["buffer-size"]().as_int());
         }
 
-    	if(!fHilbertTransform.Configure(aParam))
+    	if(!fHilbertTransform.Configure(tParam))
     	{
     		LERROR(lmclog,"Error configuring buffer sizes in receiver HilbertTransform class");
     	}
+
+
+
+
+        fInterface->fConfigureKass = new ConfigureKass();
+        fInterface->fConfigureKass->SetParameters( tParam );
+
+     	return true;
+    }
+
+
+
+
+    bool ArraySignalGenerator::Configure( const scarab::param_node& aParam )
+    {
+
+    	SetParameters( aParam );
+
 
         if( aParam.has( "lo-frequency" ) )
         {
@@ -327,6 +359,17 @@ namespace locust
 
         return true;
     }
+
+    bool ArraySignalGenerator::RecordRunParameters( Signal* aSignal )
+    {
+    	fInterface->aRunParameter = new RunParameters();
+    	fInterface->aRunParameter->fSamplingRateMHz = fAcquisitionRate;
+    	fInterface->aRunParameter->fDecimationFactor = aSignal->DecimationFactor();
+    	fInterface->aRunParameter->fLOfrequency = fLO_Frequency;
+
+    	return true;
+    }
+
 
     void ArraySignalGenerator::Accept( GeneratorVisitor* aVisitor ) const
     {
@@ -619,6 +662,9 @@ namespace locust
 
     bool ArraySignalGenerator::DoGenerate( Signal* aSignal )
     {
+
+        ConfigureInterface( aSignal );
+        RecordRunParameters( aSignal );
 
         if(!InitializeElementArray())
         {

--- a/Source/Generators/LMCArraySignalGenerator.hh
+++ b/Source/Generators/LMCArraySignalGenerator.hh
@@ -64,6 +64,11 @@ namespace locust
             virtual ~ArraySignalGenerator();
 
             bool Configure( const scarab::param_node& aNode );
+            bool ConfigureInterface(Signal* aSignal);
+            bool RecordRunParameters(Signal* aSignal);
+            const scarab::param_node* GetParameters();
+            void SetParameters( const scarab::param_node& aNode );
+
 
             void Accept( GeneratorVisitor* aVisitor ) const;
               
@@ -124,6 +129,8 @@ namespace locust
             HilbertTransform fHilbertTransform;
 
             kl_interface_ptr_t fInterface;
+            const scarab::param_node* fParam;
+
 
 
     };

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -300,6 +300,18 @@ namespace locust
         return true;
     }
 
+    bool CavitySignalGenerator::RecordRunParameters( Signal* aSignal )
+    {
+    	fInterface->aRunParameter = new RunParameters();
+    	fInterface->aRunParameter->fSamplingRateMHz = fAcquisitionRate;
+    	fInterface->aRunParameter->fDecimationFactor = aSignal->DecimationFactor();
+    	fInterface->aRunParameter->fLOfrequency = fLO_Frequency;
+
+    	return true;
+    }
+
+
+
     bool CavitySignalGenerator::SetSeed(int aSeed)
     {
         LPROG(lmclog,"Setting random seed for track delay to " << aSeed);
@@ -566,6 +578,7 @@ namespace locust
     bool CavitySignalGenerator::DoGenerateTime( Signal* aSignal )
     {
         ConfigureInterface( aSignal );
+        RecordRunParameters( aSignal );
 
         if (fRandomPreEventSamples) RandomizeStartDelay();
 

--- a/Source/Generators/LMCCavitySignalGenerator.hh
+++ b/Source/Generators/LMCCavitySignalGenerator.hh
@@ -73,6 +73,7 @@ namespace locust
 
             bool Configure( const scarab::param_node& aNode );
             bool ConfigureInterface(Signal* aSignal);
+            bool RecordRunParameters(Signal* aSignal);
             bool CrossCheckCavityConfig();
             bool CrossCheckAliasing(Signal* aSignal, double dopplerFrequency );
 

--- a/Source/Generators/LMCGaussianNoiseGenerator.cc
+++ b/Source/Generators/LMCGaussianNoiseGenerator.cc
@@ -26,9 +26,7 @@ namespace locust
         fMean( 0. ),
         fSigma( 1. ),
         fRandomSeed( 0 ),
-        fNormDist( fMean, fSigma ),
-		fWriteRootTree( false ),
-        fRootFilename( "LocustNoise.root")
+        fNormDist( fMean, fSigma )
     {
         fRequiredSignalState = Signal::kFreq;
     }
@@ -58,19 +56,6 @@ namespace locust
             LERROR( lmclog, "LMCGaussianNoiseGenerator has been configured without a noise background.");
             exit(-1);
             return false;
-        }
-
-        if (aParam.has( "write-root-tree" ))
-        {
-            if (aParam["write-root-tree"]().as_bool())
-            {
-            	fWriteRootTree = true;
-            }
-        }
-
-    	if( aParam.has( "root-filename" ) )
-        {
-            fRootFilename = aParam["root-filename"]().as_string();
         }
 
 
@@ -173,24 +158,6 @@ namespace locust
         return;
     }
 
-
-    bool GaussianNoiseGenerator::WriteRootTree()
-    {
-		#ifdef ROOT_FOUND
-    	FileWriter* aRootTreeWriter = RootTreeWriter::get_instance();
-    	aRootTreeWriter->SetFilename(fRootFilename);
-    	aRootTreeWriter->OpenFile("UPDATE");
-        RunParameters* aRunParameter = new RunParameters();
-        aRunParameter->fNoise = fSigma*fSigma;
-        aRootTreeWriter->WriteRunParameters(aRunParameter, "Noise");
-        aRootTreeWriter->CloseFile();
-        delete aRunParameter;
-		#endif
-
-        return true;
-    }
-
-
     bool GaussianNoiseGenerator::DoGenerate( Signal* aSignal )
     {
         return (this->*fDoGenerateFunc)( aSignal );
@@ -212,7 +179,6 @@ namespace locust
         std::default_random_engine generator(random_seed_val);
 
     	SetMeanAndSigma( fMean, fSigma, fSigma * sqrt(fAcquisitionRate * 1.e6) );
-    	if (fWriteRootTree) WriteRootTree();
 
         double gain=1.;
         const unsigned nchannels = fNChannels;

--- a/Source/Generators/LMCGaussianNoiseGenerator.hh
+++ b/Source/Generators/LMCGaussianNoiseGenerator.hh
@@ -12,11 +12,6 @@
 #include "LMCRunLengthCalculator.hh"
 #include "LMCConst.hh"
 
-#ifdef ROOT_FOUND
-    #include "LMCRunParameters.hh"
-    #include "LMCRootTreeWriter.hh"
-#endif
-
 #include <random>
 
 namespace locust
@@ -38,13 +33,8 @@ namespace locust
      - "noise-temperature": double -- Noise temperature in K.
      - "domain": string -- Determines whether the noise is generated in the time or frequency domain
                            Available options: "time" and "freq" [default]
-     - "write-root-tree": boolean -- Flag to control whether or not value of noise power is written
-     	 	 			  to output Root file as a LMCRunParameter.
      - "random-seed": int -- Random seed used to generate random noise.  If this is omitted then the
      	 	 	 	 	  noise spectrum is reproducible.
-     - "root-filename": string -- Name of output Root file.  This can have the same name as other
-          	 	 	 	  generators' output Root files, in which case all of the Root objects will
-          	 	 	 	  be written to the same output file.
 
     */
     class GaussianNoiseGenerator : public Generator
@@ -76,7 +66,6 @@ namespace locust
             void SetDomain( Signal::State aDomain );
 
         private:
-            bool WriteRootTree();
             bool DoGenerate( Signal* aSignal );
 
             bool DoGenerateTime( Signal* aSignal );
@@ -87,8 +76,6 @@ namespace locust
             double fMean;
             double fSigma;
             int fRandomSeed;
-            bool fWriteRootTree;
-            std::string fRootFilename;
 
             mutable std::normal_distribution< double > fNormDist;
     };

--- a/Source/IO/LMCFileWriter.hh
+++ b/Source/IO/LMCFileWriter.hh
@@ -43,7 +43,7 @@ namespace locust
         virtual double GetTestVar() {return 0.;};
         virtual void SetTestVar(double aValue) {};
         virtual void WriteEvent(Event* anEvent) {};
-        virtual void WriteRunParameters( RunParameters* aRunParameter, const char* aParameterName ) {};
+        virtual void WriteRunParameters( RunParameters* aRunParameter) {};
         virtual void Write1DHisto(TH1D* aHisto) {};
         virtual void Write2DHisto(TH2D* aHisto) {};
         virtual void WriteVector1DHisto(std::vector<double> aVector, double xmin, double xmax) {};

--- a/Source/IO/LMCRootTreeWriter.cc
+++ b/Source/IO/LMCRootTreeWriter.cc
@@ -35,22 +35,16 @@ namespace locust
     	return true;
     }
 
-    void RootTreeWriter::WriteRunParameters( RunParameters* aRunParameter, const char* aParameterName )
+    void RootTreeWriter::WriteRunParameters( RunParameters* aRunParameter)
     {
         TTree *aTree = new TTree("Run Parameters","Locust Tree");
-
-        if (aParameterName=="Noise")
-        	{
-        	aTree->Branch("Noise", &aRunParameter->fNoise, "Noise/D");
-        	}
-        if (aParameterName=="LOfrequency")
-        	{
-        	aTree->Branch("LO frequency", &aRunParameter->fLOfrequency, "LOfrequency/D");
-        	}
-
+        aTree->Branch("LOFrequency", &aRunParameter->fLOfrequency, "LOfrequency/D");
+        aTree->Branch("SamplingFrequencyMHz", &aRunParameter->fSamplingRateMHz, "SamplingFrequency/D");
+        aTree->Branch("DecimationRate", &aRunParameter->fDecimationFactor, "DecimationFactor/D");
         aTree->Fill();
         aTree->Write();
         delete aTree;
+
     }
 
     void RootTreeWriter::WriteEvent(Event* anEvent)

--- a/Source/IO/LMCRootTreeWriter.hh
+++ b/Source/IO/LMCRootTreeWriter.hh
@@ -34,7 +34,7 @@ namespace locust
         allow_singleton_access( RootTreeWriter );
 
         virtual void WriteEvent(Event* anEvent);
-        virtual void WriteRunParameters( RunParameters* aRunParameter, const char* aParameterName );
+        virtual void WriteRunParameters( RunParameters* aRunParameter);
 
         private:
 

--- a/Source/IO/LMCRunParameters.hh
+++ b/Source/IO/LMCRunParameters.hh
@@ -28,6 +28,8 @@ namespace locust
 
             double fNoise;
             double fLOfrequency;
+            double fSamplingRateMHz;
+            double fDecimationFactor;
 
             ClassDef(RunParameters,1)  // Root syntax.
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -243,7 +243,7 @@ namespace locust
                 {
                     // If the Locust sample index has not advanced yet, keep checking it.
                     tTriggerConfirm += 1;
-                    if (tgamma(10) < tgamma(11)) continue;  // wait small amount of time.
+                    if ( 0 < 1 ) continue;  // wait small amount of time.
                     if ( tTriggerConfirm % 1000 == 0 )
                     {
                     	LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm );

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -243,7 +243,7 @@ namespace locust
                 {
                     // If the Locust sample index has not advanced yet, keep checking it.
                     tTriggerConfirm += 1;
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    if (tgamma(10) < tgamma(11)) continue;  // wait small amount of time.
                     if ( tTriggerConfirm % 1000 == 0 )
                     {
                     	LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm );

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -56,7 +56,7 @@ namespace locust
 
     bool CyclotronRadiationExtractor::UpdateTrackProperties( Kassiopeia::KSParticle &aFinalParticle, unsigned index, bool bStart )
     {
-    	double tTime = index;
+    	double tTime = index / fInterface->aRunParameter->fSamplingRateMHz / 1.e6 / fInterface->aRunParameter->fDecimationFactor;
 #ifdef ROOT_FOUND
     	if (bStart)
     	{

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -12,7 +12,6 @@
 
 #ifdef ROOT_FOUND
     #include "LMCRootTreeWriter.hh"
-    #include "LMCEvent.hh"
 #endif
 
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -48,7 +48,11 @@ namespace locust
 
             void SetTrajectory( Kassiopeia::KSTrajectory* aTrajectory );
             void SetP8Phase( int P8Phase );
-            bool UpdateTrackTime( Kassiopeia::KSParticle &aFinalParticle, unsigned index, bool bStart );
+            bool UpdateTrackProperties( Kassiopeia::KSParticle &aFinalParticle, unsigned index, bool bStart );
+            double calcOrbitPhase(double tX, double tY);
+            double quadrantOrbitCorrection(double phase, double vx);
+
+
 
 
         private:

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -10,6 +10,12 @@
 #include "LMCParticle.hh"
 #include "LMCException.hh"
 
+#ifdef ROOT_FOUND
+    #include "LMCRootTreeWriter.hh"
+    #include "LMCEvent.hh"
+#endif
+
+
 
 #include <deque>
 
@@ -42,6 +48,7 @@ namespace locust
 
             void SetTrajectory( Kassiopeia::KSTrajectory* aTrajectory );
             void SetP8Phase( int P8Phase );
+            bool UpdateTrackTime( Kassiopeia::KSParticle &aFinalParticle, unsigned index, bool bStart );
 
 
         private:

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -15,11 +15,13 @@ namespace locust
 	LOGGER( lmclog, "EventHold" );
 
     EventHold::EventHold() :
+            fTruthOutputFilename("LocustEventProperties.root"),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     }
 
     EventHold::EventHold( const EventHold& aOrig ) : KSComponent(),
+            fTruthOutputFilename("LocustEventProperties.root"),
             fInterface( aOrig.fInterface )
     {
     }
@@ -60,6 +62,10 @@ namespace locust
 	    {
 	    	fInterface->anEvent->fRandomSeed = aParam["random-track-seed"]().as_int();
 	    }
+	    if ( aParam.has( "truth-output-filename" ) )
+	    {
+	    	fTruthOutputFilename = aParam["truth-output-filename"]().as_string();
+	    }
 
 
     	return true;
@@ -84,7 +90,7 @@ namespace locust
     bool EventHold::WriteEvent()
     {
         std::string tOutputPath = TOSTRING(PB_OUTPUT_DIR);
-        std::string sFileName = tOutputPath+"/LocustEventProperties.root";
+        std::string sFileName = tOutputPath+"/"+fTruthOutputFilename;
 #ifdef ROOT_FOUND
         FileWriter* aRootTreeWriter = RootTreeWriter::get_instance();
         aRootTreeWriter->SetFilename(sFileName);

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -50,7 +50,7 @@ namespace locust
 #ifdef ROOT_FOUND
         FileWriter* aRootTreeWriter = RootTreeWriter::get_instance();
         aRootTreeWriter->SetFilename("LocustEventProperties.root");
-        aRootTreeWriter->OpenFile("UPDATE");
+        aRootTreeWriter->OpenFile("RECREATE");
         fInterface->anEvent->AddTrack( fInterface->aTrack );
         aRootTreeWriter->WriteEvent( fInterface->anEvent );
         aRootTreeWriter->CloseFile();

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -33,6 +33,39 @@ namespace locust
         return new EventHold( *this );
     }
 
+    bool EventHold::ConfigureByInterface()
+    {
+        OpenEvent();
+
+    	if (fInterface->fConfigureKass)
+    	{
+    	    const scarab::param_node* aParam = fInterface->fConfigureKass->GetParameters();
+    	    if (!this->Configure( *aParam ))
+    	    {
+                LERROR(lmclog,"Error configuring EventHold class");
+                return false;
+    	    }
+    	}
+    	else
+    	{
+            LPROG(lmclog,"EventHold class did not need to be configured.");
+            return true;
+    	}
+        return true;
+    }
+
+    bool EventHold::Configure( const scarab::param_node& aParam )
+    {
+	    if ( aParam.has( "random-track-seed" ) )
+	    {
+	    	fInterface->anEvent->fRandomSeed = aParam["random-track-seed"]().as_int();
+	    }
+
+
+    	return true;
+    }
+
+
 
     bool EventHold::OpenEvent()
     {
@@ -41,6 +74,7 @@ namespace locust
         fInterface->anEvent->fEventID = 0;
         fInterface->anEvent->fRandomSeed = -99;
         fInterface->anEvent->fLOFrequency = -99.;
+        fInterface->anEvent->fRandomSeed = -99;
 #endif
 
         return true;
@@ -65,8 +99,11 @@ namespace locust
 
     bool EventHold::ExecutePreEventModification(Kassiopeia::KSEvent &anEvent)
     {
+    	if ( !ConfigureByInterface() )
+    	{
+    	    return false;
+    	}
 
-        OpenEvent();
         LPROG( lmclog, "Kass is waiting for event trigger" );
 
         fInterface->fDigitizerCondition.notify_one();  // unlock if still locked.

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -49,9 +49,11 @@ namespace locust
 
     bool EventHold::WriteEvent()
     {
+        std::string tOutputPath = TOSTRING(PB_OUTPUT_DIR);
+        std::string sFileName = tOutputPath+"/LocustEventProperties.root";
 #ifdef ROOT_FOUND
         FileWriter* aRootTreeWriter = RootTreeWriter::get_instance();
-        aRootTreeWriter->SetFilename("LocustEventProperties.root");
+        aRootTreeWriter->SetFilename(sFileName);
         aRootTreeWriter->OpenFile("RECREATE");
         fInterface->anEvent->AddTrack( fInterface->aTrack );
         aRootTreeWriter->WriteEvent( fInterface->anEvent );

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -38,7 +38,9 @@ namespace locust
     {
 #ifdef ROOT_FOUND
         fInterface->anEvent = new Event();
-        fInterface->anEvent->fNTracks = 0;
+        fInterface->anEvent->fEventID = 0;
+        fInterface->anEvent->fRandomSeed = -99;
+        fInterface->anEvent->fLOFrequency = -99.;
 #endif
 
         return true;
@@ -53,6 +55,7 @@ namespace locust
         aRootTreeWriter->OpenFile("RECREATE");
         fInterface->anEvent->AddTrack( fInterface->aTrack );
         aRootTreeWriter->WriteEvent( fInterface->anEvent );
+        aRootTreeWriter->WriteRunParameters(fInterface->aRunParameter);
         aRootTreeWriter->CloseFile();
 #endif
         return true;

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -34,6 +34,7 @@ namespace locust
             EventHold* Clone() const;
             bool ConfigureByInterface();
             bool Configure( const scarab::param_node& aParam );
+            std::string fTruthOutputFilename;
 
 
         public:

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -13,6 +13,12 @@
 
 #include "LMCKassLocustInterface.hh"
 
+#ifdef ROOT_FOUND
+    #include "LMCRootTreeWriter.hh"
+    #include "LMCEvent.hh"
+#endif
+
+
 namespace locust
 {
 
@@ -22,6 +28,8 @@ namespace locust
         public:
             EventHold();
             EventHold( const EventHold& aOrig );
+            bool OpenEvent();
+            bool WriteEvent();
             virtual ~EventHold();
 
             EventHold* Clone() const;

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -32,6 +32,9 @@ namespace locust
             virtual ~EventHold();
 
             EventHold* Clone() const;
+            bool ConfigureByInterface();
+            bool Configure( const scarab::param_node& aParam );
+
 
         public:
 

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -15,7 +15,6 @@
 
 #ifdef ROOT_FOUND
     #include "LMCRootTreeWriter.hh"
-    #include "LMCEvent.hh"
 #endif
 
 

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -20,6 +20,9 @@
 #include <memory>
 #include <mutex>
 
+#ifdef ROOT_FOUND
+    #include "LMCEvent.hh"
+#endif
 
 namespace locust
 {
@@ -69,6 +72,13 @@ namespace locust
         int fTriggerConfirm;
         int fFastRecordLength;
 
+#ifdef ROOT_FOUND
+        Event* anEvent;
+        Track aTrack;
+#endif
+
+
+
 
     };
 
@@ -91,6 +101,7 @@ namespace locust
             ~KLInterfaceBootstrapper();
 
             kl_interface_ptr_t fInterface;
+
     };
 
 } /* namespace locust */

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -21,7 +21,7 @@
 #include <mutex>
 
 #ifdef ROOT_FOUND
-    #include "LMCEvent.hh"
+    #include "LMCRootTreeWriter.hh"
 #endif
 
 namespace locust
@@ -75,6 +75,7 @@ namespace locust
 #ifdef ROOT_FOUND
         Event* anEvent;
         Track aTrack;
+        RunParameters* aRunParameter;
 #endif
 
 

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -272,7 +272,14 @@ namespace locust
         {
 
             double tMaxTrackLength = 0.;
+            double tMinTrackLengthFraction = 0.1;
             fLocustMaxTimeTerminator = new Kassiopeia::KSTermMaxTime();
+
+    	    if ( aParam.has( "min-track-length-fraction" ) )
+    	    {
+    	    	tMinTrackLengthFraction = aParam["min-track-length-fraction"]().as_double();
+                LPROG(lmclog,"Setting minimum track length fraction to " << tMinTrackLengthFraction);
+    	    }
 
     	    if ( aParam.has( "track-length" ) )
     	    {
@@ -290,7 +297,8 @@ namespace locust
                 if ( aParam["random-track-length"]().as_bool() == true)
                 {
                     srand ( GetSeed( aParam ));
-                    double tRandomTime = tMaxTrackLength/10. * ( 1 + rand() % 10 ); // 0.1*tMaxTrackLength < t < 1.1*tMaxTrackLength
+                    double tMinTrackLength = tMaxTrackLength * tMinTrackLengthFraction;
+                    double tRandomTime = tMinTrackLength + (tMaxTrackLength - tMinTrackLength) * (rand() % 10) / 9.;
                     fLocustMaxTimeTerminator->SetTime( tRandomTime );
                     LPROG(lmclog,"Randomizing the track length to " << tRandomTime);
                 }


### PR DESCRIPTION
In this pull request two Root TTrees are written to one file during the simulation.  The first TTree contains event properties, and the second TTree contains run parameters.  Both trees can be expanded as needed.  Not included in these changes (yet) are an output text file in parallel with the Root file.  This could be implemented now, depending on needs, or in the future. 

For historical reasons, there are some run parameters in the TTree that have typically been defined in the FTG, but are not presently parameterized inputs to Locust-Kass (slope and power).  They are left in the TTree with values of -99.

![image](https://github.com/project8/locust_mc/assets/6953145/b2b5aace-169d-4cc9-be06-6af107466cdd)
