### PR TITLE
Update event properties output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/truthWriting]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/truthWriting]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 2.7.2)
+project( locust_mc VERSION 2.8.0)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/IO/LMCEvent.cc
+++ b/Source/IO/LMCEvent.cc
@@ -24,6 +24,7 @@ namespace locust
     {
         fStartFrequencies.push_back( aTrack.StartFrequency );
         fEndFrequencies.push_back( aTrack.EndFrequency );
+        fAvgFrequencies.push_back( aTrack.AvgFrequency );
         fTrackPowers.push_back( aTrack.TrackPower );
         fStartTimes.push_back( aTrack.StartTime );
         fTrackLengths.push_back( aTrack.TrackLength );

--- a/Source/IO/LMCEvent.hh
+++ b/Source/IO/LMCEvent.hh
@@ -35,6 +35,7 @@ namespace locust
 
             std::vector<double> fStartFrequencies;
             std::vector<double> fEndFrequencies;
+            std::vector<double> fAvgFrequencies;
             std::vector<double> fTrackPowers;
             std::vector<double> fStartTimes;
             std::vector<double> fEndTimes;

--- a/Source/IO/LMCRootTreeWriter.cc
+++ b/Source/IO/LMCRootTreeWriter.cc
@@ -58,6 +58,7 @@ namespace locust
         aTree->Branch("ntracks", &anEvent->fNTracks, "ntracks/I");
         aTree->Branch("StartFrequencies", "std::vector<double>", &anEvent->fStartFrequencies);
         aTree->Branch("EndFrequencies", "std::vector<double>", &anEvent->fEndFrequencies);
+        aTree->Branch("AvgFrequencies", "std::vector<double>", &anEvent->fAvgFrequencies);
         aTree->Branch("StartTimes", "std::vector<double>", &anEvent->fStartTimes);
         aTree->Branch("EndTimes", "std::vector<double>", &anEvent->fEndTimes);
         aTree->Branch("TrackLengths", "std::vector<double>", &anEvent->fTrackLengths);

--- a/Source/IO/LMCTrack.hh
+++ b/Source/IO/LMCTrack.hh
@@ -34,6 +34,7 @@ namespace locust
             double TrackLength = -99.;
             double StartFrequency = -99.;
             double EndFrequency = -99.;
+            double AvgFrequency = -99.;
             double LOFrequency = -99.;
             double TrackPower = -99.;
             double Slope = -99.;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -60,6 +60,7 @@ namespace locust
 #ifdef ROOT_FOUND
     	if (bStart)
     	{
+            fStartingIndex = index;
             fInterface->aTrack.StartTime = tTime;
             fInterface->aTrack.StartFrequency = aFinalParticle.GetCyclotronFrequency();
             double tX = aFinalParticle.GetPosition().X();
@@ -72,6 +73,8 @@ namespace locust
     	{
             fInterface->aTrack.EndTime = tTime;
             fInterface->aTrack.EndFrequency = aFinalParticle.GetCyclotronFrequency();
+            unsigned nElapsedSamples = index - fStartingIndex;
+            fInterface->aTrack.AvgFrequency = ( fInterface->aTrack.AvgFrequency * nElapsedSamples + aFinalParticle.GetCyclotronFrequency() ) / ( nElapsedSamples + 1);
     	}
 #endif
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -75,6 +75,8 @@ namespace locust
             fInterface->aTrack.EndFrequency = aFinalParticle.GetCyclotronFrequency();
             unsigned nElapsedSamples = index - fStartingIndex;
             fInterface->aTrack.AvgFrequency = ( fInterface->aTrack.AvgFrequency * nElapsedSamples + aFinalParticle.GetCyclotronFrequency() ) / ( nElapsedSamples + 1);
+            fInterface->aTrack.TrackLength = tTime - fInterface->aTrack.StartTime;
+            fInterface->aTrack.Slope = (fInterface->aTrack.EndFrequency - fInterface->aTrack.StartFrequency) / (fInterface->aTrack.TrackLength);
     	}
 #endif
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -60,6 +60,7 @@ namespace locust
             FieldCalculator* fFieldCalculator;
             kl_interface_ptr_t fInterface;
             unsigned fSampleIndex;
+            unsigned fStartingIndex;
     };
 
 

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -16,12 +16,14 @@ namespace locust
 
     EventHold::EventHold() :
             fTruthOutputFilename("LocustEventProperties.root"),
+            fAccumulateTruthInfo( false ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     }
 
     EventHold::EventHold( const EventHold& aOrig ) : KSComponent(),
             fTruthOutputFilename("LocustEventProperties.root"),
+            fAccumulateTruthInfo( false ),
             fInterface( aOrig.fInterface )
     {
     }
@@ -66,6 +68,10 @@ namespace locust
 	    {
 	    	fTruthOutputFilename = aParam["truth-output-filename"]().as_string();
 	    }
+	    if ( aParam.has( "accumulate-truth-info" ) )
+	    {
+	    	fAccumulateTruthInfo = aParam["accumulate-truth-info"]().as_bool();
+	    }
 
 
     	return true;
@@ -94,7 +100,17 @@ namespace locust
 #ifdef ROOT_FOUND
         FileWriter* aRootTreeWriter = RootTreeWriter::get_instance();
         aRootTreeWriter->SetFilename(sFileName);
-        aRootTreeWriter->OpenFile("RECREATE");
+        if (fAccumulateTruthInfo)
+        {
+        	// This option should be used when running pileup.  We will need to
+        	// figure out how to explicitly increment the event ID, given that the
+        	// same (identical) simulation is being run multiple times in this case.
+        	aRootTreeWriter->OpenFile("UPDATE");
+        }
+        else
+        {
+        	aRootTreeWriter->OpenFile("RECREATE");
+        }
         fInterface->anEvent->AddTrack( fInterface->aTrack );
         aRootTreeWriter->WriteEvent( fInterface->anEvent );
         aRootTreeWriter->WriteRunParameters(fInterface->aRunParameter);

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -35,6 +35,7 @@ namespace locust
             bool ConfigureByInterface();
             bool Configure( const scarab::param_node& aParam );
             std::string fTruthOutputFilename;
+            bool fAccumulateTruthInfo;
 
 
         public:


### PR DESCRIPTION
These changes include an option to record event properties for multiple events in one file, in case of pileup.  There are also more event properties recorded for each event.