### PR TITLE
Feature/event recording

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/eventRecording]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/eventRecording]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 2.8.1)
+project( locust_mc VERSION 2.8.2)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -309,6 +309,7 @@ namespace locust
     	fInterface->aRunParameter->fSamplingRateMHz = fAcquisitionRate;
     	fInterface->aRunParameter->fDecimationFactor = aSignal->DecimationFactor();
     	fInterface->aRunParameter->fLOfrequency = fLO_Frequency;
+    	fInterface->aRunParameter->fRandomSeed = fTrackDelaySeed;
 #endif
     	return true;
     }

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -262,7 +262,9 @@ namespace locust
                 }
         	    if ( aParam.has( "random-track-seed" ) )
         	    {
-        	        SetSeed( aParam["random-track-seed"]().as_int() );
+        	    	// Offset event-spacing seed from track-length seed.
+        	    	int tSeed = aParam["random-track-seed"]().as_int() + 1;
+        	        SetSeed( tSeed );
         	    }
         	    else
         	    {
@@ -302,11 +304,12 @@ namespace locust
 
     bool CavitySignalGenerator::RecordRunParameters( Signal* aSignal )
     {
+#ifdef ROOT_FOUND
     	fInterface->aRunParameter = new RunParameters();
     	fInterface->aRunParameter->fSamplingRateMHz = fAcquisitionRate;
     	fInterface->aRunParameter->fDecimationFactor = aSignal->DecimationFactor();
     	fInterface->aRunParameter->fLOfrequency = fLO_Frequency;
-
+#endif
     	return true;
     }
 

--- a/Source/IO/LMCEvent.cc
+++ b/Source/IO/LMCEvent.cc
@@ -35,7 +35,10 @@ namespace locust
         fRadii.push_back( aTrack.Radius );
         fRadialPhases.push_back( aTrack.RadialPhase );
 
-        //update size
+        // Update size.  And, record fLOFrequency for compatibility with previous work.  The LO frequency is
+        // now also recorded in the RunParameters Tree.
         fNTracks = fStartFrequencies.size();
+        fLOFrequency = aTrack.LOFrequency;
+        fRandomSeed = aTrack.RandomSeed;
     }
 }

--- a/Source/IO/LMCEvent.cc
+++ b/Source/IO/LMCEvent.cc
@@ -22,6 +22,7 @@ namespace locust
 
     void Event::AddTrack(const Track aTrack)
     {
+        fOutputStartFrequencies.push_back( aTrack.OutputStartFrequency );
         fStartFrequencies.push_back( aTrack.StartFrequency );
         fEndFrequencies.push_back( aTrack.EndFrequency );
         fAvgFrequencies.push_back( aTrack.AvgFrequency );

--- a/Source/IO/LMCEvent.hh
+++ b/Source/IO/LMCEvent.hh
@@ -33,6 +33,7 @@ namespace locust
             double fLOFrequency;
             int fRandomSeed;
 
+            std::vector<double> fOutputStartFrequencies;
             std::vector<double> fStartFrequencies;
             std::vector<double> fEndFrequencies;
             std::vector<double> fAvgFrequencies;

--- a/Source/IO/LMCRootTreeWriter.cc
+++ b/Source/IO/LMCRootTreeWriter.cc
@@ -56,6 +56,7 @@ namespace locust
         TTree *aTree = new TTree(treename,"Locust Tree");
         aTree->Branch("EventID", &anEvent->fEventID, "EventID/I");
         aTree->Branch("ntracks", &anEvent->fNTracks, "ntracks/I");
+        aTree->Branch("OutputStartFrequencies", "std::vector<double>", &anEvent->fOutputStartFrequencies);
         aTree->Branch("StartFrequencies", "std::vector<double>", &anEvent->fStartFrequencies);
         aTree->Branch("EndFrequencies", "std::vector<double>", &anEvent->fEndFrequencies);
         aTree->Branch("AvgFrequencies", "std::vector<double>", &anEvent->fAvgFrequencies);

--- a/Source/IO/LMCRunParameters.hh
+++ b/Source/IO/LMCRunParameters.hh
@@ -30,6 +30,7 @@ namespace locust
             double fLOfrequency;
             double fSamplingRateMHz;
             double fDecimationFactor;
+            int fRandomSeed;
 
             ClassDef(RunParameters,1)  // Root syntax.
 

--- a/Source/IO/LMCTrack.hh
+++ b/Source/IO/LMCTrack.hh
@@ -32,6 +32,7 @@ namespace locust
             double StartTime = -99.;
             double EndTime = -99.;
             double TrackLength = -99.;
+            double OutputStartFrequency = -99.;
             double StartFrequency = -99.;
             double EndFrequency = -99.;
             double AvgFrequency = -99.;

--- a/Source/IO/LMCTrack.hh
+++ b/Source/IO/LMCTrack.hh
@@ -29,6 +29,7 @@ namespace locust
             Track();
             virtual ~Track();
             int EventID = -99;
+            int RandomSeed = -99.;
             double StartTime = -99.;
             double EndTime = -99.;
             double TrackLength = -99.;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -132,12 +132,19 @@ namespace locust
             if (fPitchAngle == -99.)  // first crossing of center
             {
                 fPitchAngle = aFinalParticle.GetPolarAngleToB();
+#ifdef ROOT_FOUND
                 fInterface->aTrack.PitchAngle = aFinalParticle.GetPolarAngleToB();
                 fInterface->aTrack.StartFrequency = aFinalParticle.GetCyclotronFrequency();
+                double tLOfrequency = fInterface->aRunParameter->fLOfrequency; // Hz
+                double tSamplingRate = fInterface->aRunParameter->fSamplingRateMHz; // MHz
+                fInterface->aTrack.OutputStartFrequency = fInterface->aTrack.StartFrequency - tLOfrequency + tSamplingRate * 1.e6 / 2.;
+#endif
             }
             else
             {
+#ifdef ROOT_FOUND
                 fInterface->aTrack.EndFrequency = aFinalParticle.GetCyclotronFrequency();
+#endif
             }
         }
         aNewParticle.SetPitchAngle(fPitchAngle);

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -137,6 +137,8 @@ namespace locust
                 fInterface->aTrack.StartFrequency = aFinalParticle.GetCyclotronFrequency();
                 double tLOfrequency = fInterface->aRunParameter->fLOfrequency; // Hz
                 double tSamplingRate = fInterface->aRunParameter->fSamplingRateMHz; // MHz
+                fInterface->aTrack.LOFrequency = tLOfrequency;
+                fInterface->aTrack.RandomSeed = fInterface->aRunParameter->fRandomSeed;
                 fInterface->aTrack.OutputStartFrequency = fInterface->aTrack.StartFrequency - tLOfrequency + tSamplingRate * 1.e6 / 2.;
 #endif
             }

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -102,7 +102,7 @@ namespace locust
         aRootTreeWriter->SetFilename(sFileName);
         if (fAccumulateTruthInfo)
         {
-        	// This option should be used when running pileup.  We will need to
+        	// TO-DO:  This option should be used when running pileup.  We will need to
         	// figure out how to explicitly increment the event ID, given that the
         	// same (identical) simulation is being run multiple times in this case.
         	aRootTreeWriter->OpenFile("UPDATE");

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -24,6 +24,7 @@ namespace locust
     RunPause::RunPause() :
         fToolbox(KToolbox::GetInstance()),
         KSComponent(),
+        fMinTrackLengthFraction(0.1),
         fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     }
@@ -31,6 +32,7 @@ namespace locust
     RunPause::RunPause( const RunPause& aCopy ) :
         fToolbox(KToolbox::GetInstance()),
         KSComponent(),
+        fMinTrackLengthFraction(0.1),
         fInterface( aCopy.fInterface )
     {
     }
@@ -272,13 +274,12 @@ namespace locust
         {
 
             double tMaxTrackLength = 0.;
-            double tMinTrackLengthFraction = 0.1;
             fLocustMaxTimeTerminator = new Kassiopeia::KSTermMaxTime();
 
     	    if ( aParam.has( "min-track-length-fraction" ) )
     	    {
-    	    	tMinTrackLengthFraction = aParam["min-track-length-fraction"]().as_double();
-                LPROG(lmclog,"Setting minimum track length fraction to " << tMinTrackLengthFraction);
+                fMinTrackLengthFraction = aParam["min-track-length-fraction"]().as_double();
+                LPROG(lmclog,"Setting minimum track length fraction to " << fMinTrackLengthFraction);
     	    }
 
     	    if ( aParam.has( "track-length" ) )
@@ -300,7 +301,7 @@ namespace locust
                     default_setting.add("name","uniform");
                     fTrackLengthDistribution = fDistributionInterface.get_dist(default_setting);
                     fDistributionInterface.SetSeed( GetSeed(aParam) );
-                    double tMinTrackLength = tMaxTrackLength * tMinTrackLengthFraction;
+                    double tMinTrackLength = tMaxTrackLength * fMinTrackLengthFraction;
                     double tRandomTime = tMinTrackLength + (tMaxTrackLength - tMinTrackLength) * fTrackLengthDistribution->Generate();
                     fLocustMaxTimeTerminator->SetTime( tRandomTime );
                     LPROG(lmclog,"Randomizing the track length to " << tRandomTime);

--- a/Source/Kassiopeia/LMCRunPause.hh
+++ b/Source/Kassiopeia/LMCRunPause.hh
@@ -82,6 +82,7 @@ namespace locust
 
             std::shared_ptr< BaseDistribution> fTrackLengthDistribution;
             DistributionInterface fDistributionInterface;
+            double fMinTrackLengthFraction;
 
 
 


### PR DESCRIPTION
The Root output TTree structures are expanded by writing a few more event and run parameters (e.g. output start frequency, random seed, LO frequency).  Additionally, a minor change is applied to prevent the repetition of a random seed, if it is specified as an input parameter.