### PR TITLE
expand event types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 2.8.2)
+project( locust_mc VERSION 2.8.3)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -175,6 +175,8 @@ if (locust_mc_BUILD_WITH_KASSIOPEIA)
         Kassiopeia/LMCFieldCalculator.hh
         Kassiopeia/LMCEventHold.hh
         Kassiopeia/LMCEventHoldBuilder.hh
+        Kassiopeia/LMCTrackHold.hh
+        Kassiopeia/LMCTrackHoldBuilder.hh        
         Kassiopeia/LMCKassLocustInterface.hh
         Kassiopeia/LMCRunKassiopeia.hh
         Kassiopeia/LMCRunPause.hh
@@ -211,6 +213,8 @@ if (locust_mc_BUILD_WITH_KASSIOPEIA)
         Kassiopeia/LMCFieldCalculator.cc
         Kassiopeia/LMCEventHold.cc
         Kassiopeia/LMCEventHoldBuilder.cc
+        Kassiopeia/LMCTrackHold.cc
+        Kassiopeia/LMCTrackHoldBuilder.cc
         Kassiopeia/LMCKassLocustInterface.cc
         Kassiopeia/LMCRunKassiopeia.cc
         Kassiopeia/LMCRunPause.cc

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -208,7 +208,7 @@ namespace locust
             	double dt = aFinalParticle.GetTime() - anInitialParticle.GetTime();
                 fFieldCalculator->SetNFilterBinsRequired( dt );
                 UpdateTrackProperties( aFinalParticle, fInterface->fSampleIndex, 1 );
-            	LPROG(lmclog,"Updated track properties at sample " << fInterface->fSampleIndex );
+            	LPROG(lmclog,"Updated recorded track properties at sample " << fInterface->fSampleIndex );
             }
 
 
@@ -270,7 +270,7 @@ namespace locust
                     	LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm );
                     }
 
-                    if ( ( tTriggerConfirm > fInterface->fTriggerConfirm - 3) && ( fSampleIndex < fInterface->fFastRecordLength ) )
+                    if ( ( tTriggerConfirm > fInterface->fTriggerConfirm - 3) && ( fSampleIndex < fInterface->fFastRecordLength-1 ) )
                     {
                         LPROG(lmclog,"Checking the digitizer synchronization, tTriggerConfirm index = " << tTriggerConfirm);
                         LPROG(lmclog,"Checking the digitizer synchronization, at fast sample = " << fSampleIndex);

--- a/Source/Kassiopeia/LMCTrackHold.cc
+++ b/Source/Kassiopeia/LMCTrackHold.cc
@@ -63,12 +63,17 @@ namespace locust
 
     bool TrackHold::ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack)
     {
+        double tPitchAngle = aTrack.GetInitialParticle().GetPolarAngleToB();
+        LWARN(lmclog,"LMCTrack " << fTrackCounter << " is starting, with instantaneous pitch angle " <<  tPitchAngle);
         return true;
     }
 
     bool TrackHold::ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack)
     {
-        printf("Hi, I'm the post track modifier. The track counter is %d\n", fTrackCounter); getchar();
+        double tPitchAngle = aTrack.GetFinalParticle().GetPolarAngleToB();
+        double tTime = aTrack.GetFinalParticle().GetTime();
+        LWARN(lmclog,"LMCTrack " << fTrackCounter << " is complete at Kass time " << tTime << ", with instantaneous pitch angle " <<  tPitchAngle);
+        fTrackCounter += 1;
         return true;
     }
 

--- a/Source/Kassiopeia/LMCTrackHold.cc
+++ b/Source/Kassiopeia/LMCTrackHold.cc
@@ -1,0 +1,44 @@
+/*
+ * LMCTrackHold.cc
+ *
+ *  Created on: Apr 25, 2024
+ *      Author: pslocum
+ */
+
+#include "LMCTrackHold.hh"
+
+
+namespace locust
+{
+
+TrackHold::TrackHold() {}
+
+
+
+TrackHold::TrackHold( const TrackHold& aOrig ) {}
+
+TrackHold::~TrackHold()
+{
+}
+
+TrackHold* TrackHold::Clone() const
+{
+    return new TrackHold( *this );
+}
+
+bool TrackHold::ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack)
+{
+	return true;
+}
+
+bool TrackHold::ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack)
+{
+	return true;
+}
+
+
+
+
+
+
+}  // namespace locust

--- a/Source/Kassiopeia/LMCTrackHold.cc
+++ b/Source/Kassiopeia/LMCTrackHold.cc
@@ -5,36 +5,72 @@
  *      Author: pslocum
  */
 
+#include "logger.hh"
 #include "LMCTrackHold.hh"
 
 
 namespace locust
 {
 
-TrackHold::TrackHold() {}
+    LOGGER( lmclog, "TrackHold" );
+
+    TrackHold::TrackHold() :
+        fTrackCounter( 0 ),
+        fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
+        {}
 
 
+    TrackHold::TrackHold( const TrackHold& aOrig ) : KSComponent(),
+        fTrackCounter( 0 ),
+        fInterface( aOrig.fInterface )
+        {}
 
-TrackHold::TrackHold( const TrackHold& aOrig ) {}
 
-TrackHold::~TrackHold()
-{
-}
+    TrackHold::~TrackHold()
+    {
+    }
 
-TrackHold* TrackHold::Clone() const
-{
-    return new TrackHold( *this );
-}
+    TrackHold* TrackHold::Clone() const
+    {
+        return new TrackHold( *this );
+    }
 
-bool TrackHold::ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack)
-{
-	return true;
-}
+    bool TrackHold::ConfigureByInterface()
+    {
 
-bool TrackHold::ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack)
-{
-	return true;
-}
+        if (fInterface->fConfigureKass)
+        {
+            const scarab::param_node* aParam = fInterface->fConfigureKass->GetParameters();
+            if (!this->Configure( *aParam ))
+            {
+                LERROR(lmclog,"Error configuring TrackHold class");
+                return false;
+            }
+        }
+        else
+        {
+            LPROG(lmclog,"TrackHold class did not need to be configured.");
+            return true;
+        }
+        return true;
+    }
+
+    bool TrackHold::Configure( const scarab::param_node& aParam )
+    {
+        return true;
+    }
+
+
+    bool TrackHold::ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack)
+    {
+        return true;
+    }
+
+    bool TrackHold::ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack)
+    {
+        printf("Hi, I'm the post track modifier. The track counter is %d\n", fTrackCounter); getchar();
+        return true;
+    }
 
 
 

--- a/Source/Kassiopeia/LMCTrackHold.hh
+++ b/Source/Kassiopeia/LMCTrackHold.hh
@@ -10,6 +10,8 @@
 #define LOCUST_LMCTRACKHOLD_HH_
 
 #include "KSTrackModifier.h"
+#include "KSTrack.h"
+
 #include "KSComponentTemplate.h"
 #include "LMCKassLocustInterface.hh"
 

--- a/Source/Kassiopeia/LMCTrackHold.hh
+++ b/Source/Kassiopeia/LMCTrackHold.hh
@@ -1,0 +1,41 @@
+/*
+ * LMCTrackHoldBuilder.cc
+ *
+ *  Created on: Apr 25, 2024
+ *      Author: pslocum
+ */
+
+
+#ifndef LOCUST_LMCTRACKHOLD_HH_
+#define LOCUST_LMCTRACKHOLD_HH_
+
+#include "KSTrackModifier.h"
+#include "KSComponentTemplate.h"
+
+namespace locust
+{
+
+    class TrackHold :
+        public Kassiopeia::KSComponentTemplate< TrackHold, Kassiopeia::KSTrackModifier >
+    {
+        public:
+        TrackHold();
+        TrackHold( const TrackHold& aOrig );
+        virtual ~TrackHold();
+        TrackHold* Clone() const;
+
+
+
+        public:
+
+        virtual bool ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack);
+        virtual bool ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack);
+
+
+};
+
+} /* namespace locust */
+
+
+
+#endif

--- a/Source/Kassiopeia/LMCTrackHold.hh
+++ b/Source/Kassiopeia/LMCTrackHold.hh
@@ -11,6 +11,8 @@
 
 #include "KSTrackModifier.h"
 #include "KSComponentTemplate.h"
+#include "LMCKassLocustInterface.hh"
+
 
 namespace locust
 {
@@ -24,12 +26,23 @@ namespace locust
         virtual ~TrackHold();
         TrackHold* Clone() const;
 
+        bool ConfigureByInterface();
+        bool Configure( const scarab::param_node& aParam );
+
+
 
 
         public:
 
         virtual bool ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack);
         virtual bool ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack);
+
+        protected:
+            kl_interface_ptr_t fInterface;
+
+        private:
+
+        int fTrackCounter;
 
 
 };

--- a/Source/Kassiopeia/LMCTrackHoldBuilder.cc
+++ b/Source/Kassiopeia/LMCTrackHoldBuilder.cc
@@ -1,27 +1,27 @@
 /*
- * LMCEventHoldBuilder.cc
+ * LMCTrackHoldBuilder.cc
  *
- *  Created on: Mar 13, 2016
- *      Author: nsoblath
+ *  Created on: Apr 25, 2024
+ *      Author: pslocum
  */
 
-#include "LMCEventHoldBuilder.hh"
+#include "LMCTrackHoldBuilder.hh"
 
 #include "KSRootBuilder.h"
 
 template< >
-locust::EventHoldBuilder::~KComplexElement()
+locust::TrackHoldBuilder::~KComplexElement()
 {
 }
 
 namespace locust
 {
 
-    STATICINT SLMCEventHoldStructure =
-            locust::EventHoldBuilder::Attribute< std::string >( "name" );
+    STATICINT SLMCTrackHoldStructure =
+            locust::TrackHoldBuilder::Attribute< std::string >( "name" );
 
-    STATICINT sLMCEventHold =
-            katrin::KSRootBuilder::ComplexElement< locust::EventHold >( "mod_event_hold" );
+    STATICINT sLMCTrackHold =
+            katrin::KSRootBuilder::ComplexElement< locust::TrackHold >( "mod_track_hold" );
 
 } /* namespace locust */
 

--- a/Source/Kassiopeia/LMCTrackHoldBuilder.cc
+++ b/Source/Kassiopeia/LMCTrackHoldBuilder.cc
@@ -1,0 +1,27 @@
+/*
+ * LMCEventHoldBuilder.cc
+ *
+ *  Created on: Mar 13, 2016
+ *      Author: nsoblath
+ */
+
+#include "LMCEventHoldBuilder.hh"
+
+#include "KSRootBuilder.h"
+
+template< >
+locust::EventHoldBuilder::~KComplexElement()
+{
+}
+
+namespace locust
+{
+
+    STATICINT SLMCEventHoldStructure =
+            locust::EventHoldBuilder::Attribute< std::string >( "name" );
+
+    STATICINT sLMCEventHold =
+            katrin::KSRootBuilder::ComplexElement< locust::EventHold >( "mod_event_hold" );
+
+} /* namespace locust */
+

--- a/Source/Kassiopeia/LMCTrackHoldBuilder.hh
+++ b/Source/Kassiopeia/LMCTrackHoldBuilder.hh
@@ -1,0 +1,34 @@
+/*
+ * LMCEventHoldBuilder.hh
+ *
+ *  Created on: Mar 13, 2016
+ *      Author: nsoblath
+ */
+
+#ifndef LOCUST_LMCEVENTHOLDBUILDER_HH_
+#define LOCUST_LMCEVENTHOLDBUILDER_HH_
+
+#include "KComplexElement.hh"
+
+#include "LMCEventHold.hh"
+
+namespace locust
+{
+
+    typedef katrin::KComplexElement< locust::EventHold > EventHoldBuilder;
+
+} /* namespace locust */
+
+template< >
+inline bool locust::EventHoldBuilder::AddAttribute(KContainer *aContainer)
+{
+    if( aContainer->GetName() == "name" )
+    {
+        aContainer->CopyTo( fObject, &KNamed::SetName );
+        return true;
+    }
+    return false;
+}
+
+
+#endif /* LOCUST_LMCEVENTHOLDBUILDER_HH_ */

--- a/Source/Kassiopeia/LMCTrackHoldBuilder.hh
+++ b/Source/Kassiopeia/LMCTrackHoldBuilder.hh
@@ -1,26 +1,26 @@
 /*
- * LMCEventHoldBuilder.hh
+ * LMCTrackHoldBuilder.hh
  *
  *  Created on: Mar 13, 2016
  *      Author: nsoblath
  */
 
-#ifndef LOCUST_LMCEVENTHOLDBUILDER_HH_
-#define LOCUST_LMCEVENTHOLDBUILDER_HH_
+#ifndef LOCUST_LMCTRACKHOLDBUILDER_HH_
+#define LOCUST_LMCTRACKHOLDBUILDER_HH_
 
 #include "KComplexElement.hh"
 
-#include "LMCEventHold.hh"
+#include "LMCTrackHold.hh"
 
 namespace locust
 {
 
-    typedef katrin::KComplexElement< locust::EventHold > EventHoldBuilder;
+    typedef katrin::KComplexElement< locust::TrackHold > TrackHoldBuilder;
 
 } /* namespace locust */
 
 template< >
-inline bool locust::EventHoldBuilder::AddAttribute(KContainer *aContainer)
+inline bool locust::TrackHoldBuilder::AddAttribute(KContainer *aContainer)
 {
     if( aContainer->GetName() == "name" )
     {
@@ -31,4 +31,4 @@ inline bool locust::EventHoldBuilder::AddAttribute(KContainer *aContainer)
 }
 
 
-#endif /* LOCUST_LMCEVENTHOLDBUILDER_HH_ */
+#endif /* LOCUST_LMCTRACKHOLDBUILDER_HH_ */


### PR DESCRIPTION
The changes here include a new KS[LMC]TrackModifier class toward organization and diagnostics of multi-track events.  It is only run if instantiated in the Kass xml file.  A merge is presently requested because during testing, an exception was found to be thrown for late tracks that cross the end of the digitized record.  The exception was defined in v2.6.2, and will need to be replaced with this small change.