### PR TITLE
multi-track event recording

### DIFF
--- a/Config/LocustKass_Cavity_1GHz.xml.in
+++ b/Config/LocustKass_Cavity_1GHz.xml.in
@@ -346,6 +346,8 @@
     <cycl_rad_extr name="rad_extr" P8Phase="4" /> 
     <mod_run_pause name="run_pause"/>
     <mod_event_hold name="event_hold"/>
+    <mod_track_hold name="track_hold"/>
+    
 
     <!-- writers -->
 
@@ -461,6 +463,7 @@
         writer="write_root"
         add_static_run_modifier="run_pause"
         add_static_event_modifier="event_hold"
+        add_static_track_modifier="track_hold"
         add_static_step_modifier="rad_extr"
     />
 

--- a/Config/LocustKass_Cavity_CCA.xml.in
+++ b/Config/LocustKass_Cavity_CCA.xml.in
@@ -430,9 +430,9 @@
 
 
 
-
+<!--
             <command parent="root_space_interaction" field="add_space_interaction" child="int_hydrogen"/>
-
+-->
 <!--
             <command parent="trajectory_exact" field="remove_control" child="control_cyclotron_1_16"/>
             <command parent="trajectory_exact" field="add_control" child="control_cyclotron_1_64"/>

--- a/Config/LocustKass_Cavity_CCA.xml.in
+++ b/Config/LocustKass_Cavity_CCA.xml.in
@@ -304,10 +304,12 @@
 
 	<!-- space interactions -->
 
+<!--
     <ksint_scattering name="int_scattering" split="true">
         <density_constant temperature="300." pressure="3.e-10"/>
         <calculator_constant cross_section="1.e-18"/>
     </ksint_scattering>
+-->
 
     <!-- surface interactions -->
 
@@ -315,12 +317,12 @@
 
 
 
-<!--
+
     <ksint_scattering name="int_hydrogen" split="true">
-        <density_constant name="density_constant" temperature="300." pressure="[pressure]"/>
-        <calculator_hydrogen name="calculator_hydrogen" elastic="true" excitation="true" ionisation="true"/>
+        <density_constant name="density_constant" temperature="300." pressure="3.e-2"/>
+        <calculator_hydrogen name="calculator_hydrogen" elastic="false" excitation="true" ionisation="true"/>
     </ksint_scattering>
--->
+
 
     <!-- navigators -->
 
@@ -331,7 +333,7 @@
 
     <!-- terminators -->
     <ksterm_max_steps name="term_max_steps" steps="10000"/>
-    <ksterm_min_energy name="term_min_energy" energy="0."/>
+    <ksterm_min_energy name="term_min_energy" energy="17500."/>
     <ksterm_max_energy name="term_max_energy" energy="30430."/>
     <ksterm_min_z name="term_min_z" z="-4.0"/>
     <ksterm_max_z name="term_max_z" z="4.0"/>
@@ -342,6 +344,7 @@
     <cycl_rad_extr name="rad_extr" P8Phase="4" /> 
     <mod_run_pause name="run_pause"/>
     <mod_event_hold name="event_hold"/>
+    <mod_track_hold name="track_hold"/>
 
     <!-- writers -->
 
@@ -428,7 +431,7 @@
 
 
 
-<!--            <command parent="root_space_interaction" field="add_space_interaction" child="int_scattering"/>  -->
+            <command parent="root_space_interaction" field="add_space_interaction" child="int_hydrogen"/>
 
 <!--
             <command parent="trajectory_exact" field="remove_control" child="control_cyclotron_1_16"/>
@@ -458,6 +461,7 @@
         writer="write_root"
         add_static_run_modifier="run_pause"
         add_static_event_modifier="event_hold"
+        add_static_track_modifier="track_hold"
         add_static_step_modifier="rad_extr"
     />
 

--- a/Config/LocustKass_FreeSpace_Template.xml.in
+++ b/Config/LocustKass_FreeSpace_Template.xml.in
@@ -340,6 +340,9 @@
     <cycl_rad_extr name="rad_extr" P8Phase="0" /> 
     <mod_run_pause name="run_pause"/>
     <mod_event_hold name="event_hold"/>
+    <mod_track_hold name="track_hold"/>
+    
+    
 
 
     <!-- writers -->
@@ -452,6 +455,7 @@
         writer="write_root"
         add_static_run_modifier="run_pause"
         add_static_event_modifier="event_hold"
+        add_static_track_modifier="track_hold"
         add_static_step_modifier="rad_extr"
     />
 

--- a/Source/IO/LMCTrack.cc
+++ b/Source/IO/LMCTrack.cc
@@ -20,6 +20,28 @@ namespace locust
     {
     }
 
+    bool Track::Initialize()
+    {
+        EventID = -99;
+        RandomSeed = -99.;
+        StartTime = -99.;
+        EndTime = -99.;
+        TrackLength = -99.;
+        OutputStartFrequency = -99.;
+        StartFrequency = -99.;
+        EndFrequency = -99.;
+        AvgFrequency = -99.;
+        LOFrequency = -99.;
+        TrackPower = -99.;
+        Slope = -99.;
+        PitchAngle = -99.;
+        Radius = -99.;
+        RadialPhase = -99.;
+
+        return true;
+
+    }
+
 
 } /* namespace locust */
 

--- a/Source/IO/LMCTrack.hh
+++ b/Source/IO/LMCTrack.hh
@@ -28,6 +28,7 @@ namespace locust
         public:
             Track();
             virtual ~Track();
+            bool Initialize();
             int EventID = -99;
             int RandomSeed = -99.;
             double StartTime = -99.;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -13,6 +13,7 @@ namespace locust
             fNewParticleHistory(),
             fFieldCalculator( NULL ),
             fPitchAngle( -99. ),
+            fLMCTrackID( -2 ),
             fSampleIndex( 0 ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
@@ -23,6 +24,7 @@ namespace locust
             fNewParticleHistory(),
             fFieldCalculator( NULL ),
             fPitchAngle( aCopy.fPitchAngle ),
+            fLMCTrackID( aCopy.fLMCTrackID ),
             fSampleIndex( aCopy.fSampleIndex ),
             fInterface( aCopy.fInterface )
     {
@@ -202,13 +204,15 @@ namespace locust
 
         if (!fInterface->fDoneWithSignalGeneration)  // if Locust is still acquiring voltages.
         {
-            if (!(fInterface->fTOld > 0.))
+
+            if ( aFinalParticle.GetParentTrackId() > fLMCTrackID )  // check for new track
             {
-            	fPitchAngle = -99.;  // new electron needs central pitch angle reset.
-            	double dt = aFinalParticle.GetTime() - anInitialParticle.GetTime();
+                fLMCTrackID = aFinalParticle.GetParentTrackId();
+                fPitchAngle = -99.;  // new electron needs central pitch angle reset.
+                double dt = aFinalParticle.GetTime() - anInitialParticle.GetTime();
                 fFieldCalculator->SetNFilterBinsRequired( dt );
                 UpdateTrackProperties( aFinalParticle, fInterface->fSampleIndex, 1 );
-            	LPROG(lmclog,"Updated recorded track properties at sample " << fInterface->fSampleIndex );
+                LPROG(lmclog,"Updated recorded track properties at sample " << fInterface->fSampleIndex );
             }
 
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -57,6 +57,7 @@ namespace locust
         private:
             std::deque<locust::Particle> fNewParticleHistory;
             double fPitchAngle;
+            int fLMCTrackID;
             FieldCalculator* fFieldCalculator;
             kl_interface_ptr_t fInterface;
             unsigned fSampleIndex;

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -111,7 +111,6 @@ namespace locust
         {
         	aRootTreeWriter->OpenFile("RECREATE");
         }
-        fInterface->anEvent->AddTrack( fInterface->aTrack );
         aRootTreeWriter->WriteEvent( fInterface->anEvent );
         aRootTreeWriter->WriteRunParameters(fInterface->aRunParameter);
         aRootTreeWriter->CloseFile();

--- a/Source/Kassiopeia/LMCTrackHold.cc
+++ b/Source/Kassiopeia/LMCTrackHold.cc
@@ -63,13 +63,18 @@ namespace locust
 
     bool TrackHold::ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack)
     {
+        fInterface->aTrack.Initialize();
+        double tTime = aTrack.GetInitialParticle().GetTime();
+
         double tPitchAngle = aTrack.GetInitialParticle().GetPolarAngleToB();
-        LWARN(lmclog,"LMCTrack " << fTrackCounter << " is starting, with instantaneous pitch angle " <<  tPitchAngle);
+        LWARN(lmclog,"LMCTrack " << fTrackCounter << " is starting at Kass time " << tTime << " with instantaneous pitch angle " <<  tPitchAngle);
         return true;
     }
 
     bool TrackHold::ExecutePostTrackModification(Kassiopeia::KSTrack &aTrack)
     {
+        fInterface->anEvent->AddTrack( fInterface->aTrack );
+
         double tPitchAngle = aTrack.GetFinalParticle().GetPolarAngleToB();
         double tTime = aTrack.GetFinalParticle().GetTime();
         LWARN(lmclog,"LMCTrack " << fTrackCounter << " is complete at Kass time " << tTime << ", with instantaneous pitch angle " <<  tPitchAngle);


### PR DESCRIPTION
Multi-track Kass event properties are recorded, if they occur.  Otherwise, only one track is recorded.