### PR TITLE
Feature/eventID

### DIFF
--- a/Source/IO/LMCEvent.cc
+++ b/Source/IO/LMCEvent.cc
@@ -23,7 +23,56 @@ namespace locust
     }
     Event::~Event() {}
 
-    void Event::AddTrack(const Track aTrack)
+    bool Event::Initialize()
+    {
+        time_t rawtime;
+        struct tm * timeInfo;
+        time (&rawtime);
+        timeInfo = localtime (&rawtime);
+
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+
+        int tDay = timeInfo->tm_mday;
+        int tMonth = timeInfo->tm_mon + 1;
+        int tYear = timeInfo->tm_year - 100;
+        int tMicrosec = tv.tv_usec;
+
+        fEventID = 1e12 + tDay*1e10 + tMonth*1e8 + tYear*1e6 + tMicrosec;
+        fRandomSeed = -99;
+        fLOFrequency = -99.;
+        fRandomSeed = -99;
+        return true;
+    }
+
+
+    void Event::AddTrack(const Track* aTrack) // Phase III structure
+    {
+        fTrackIDs.push_back( aTrack->TrackID );
+        fStartingEnergies_eV.push_back( aTrack->StartingEnergy_eV );
+    	fOutputStartFrequencies.push_back( aTrack->OutputStartFrequency );
+        fStartFrequencies.push_back( aTrack->StartFrequency );
+        fEndFrequencies.push_back( aTrack->EndFrequency );
+        fAvgFrequencies.push_back( aTrack->AvgFrequency );
+        fOutputAvgFrequencies.push_back( aTrack->OutputAvgFrequency );
+        fAvgAxialFrequencies.push_back( aTrack->AvgAxialFrequency );
+        fTrackPowers.push_back( aTrack->TrackPower );
+        fStartTimes.push_back( aTrack->StartTime );
+        fTrackLengths.push_back( aTrack->TrackLength );
+        fEndTimes.push_back( aTrack->EndTime );
+        fSlopes.push_back( aTrack->Slope );
+        fPitchAngles.push_back( aTrack->PitchAngle );
+        fRadii.push_back( aTrack->Radius );
+        fRadialPhases.push_back( aTrack->RadialPhase );
+
+        // Update size.  And, record fLOFrequency for compatibility with previous work.  The LO frequency is
+        // now also recorded in the RunParameters Tree.
+        fNTracks = fStartFrequencies.size();
+        fLOFrequency = aTrack->LOFrequency;
+        fRandomSeed = aTrack->RandomSeed;
+    }
+
+    void Event::AddTrack(const Track aTrack)  // Phase II structure
     {
         fStartingEnergies_eV.push_back( aTrack.StartingEnergy_eV );
     	fOutputStartFrequencies.push_back( aTrack.OutputStartFrequency );
@@ -40,11 +89,7 @@ namespace locust
         fPitchAngles.push_back( aTrack.PitchAngle );
         fRadii.push_back( aTrack.Radius );
         fRadialPhases.push_back( aTrack.RadialPhase );
-
-        // Update size.  And, record fLOFrequency for compatibility with previous work.  The LO frequency is
-        // now also recorded in the RunParameters Tree.
         fNTracks = fStartFrequencies.size();
-        fLOFrequency = aTrack.LOFrequency;
-        fRandomSeed = aTrack.RandomSeed;
     }
+
 }

--- a/Source/IO/LMCEvent.hh
+++ b/Source/IO/LMCEvent.hh
@@ -16,6 +16,11 @@
 #include "TObject.h"
 #include "LMCTrack.hh"
 #include <vector>
+#include "time.h"
+#include <sys/time.h>
+
+
+
 
 namespace locust
 {
@@ -27,12 +32,15 @@ namespace locust
             Event();
             virtual ~Event();
 
+            bool Initialize();
+            void AddTrack(const Track* aTrack);
             void AddTrack(const Track aTrack);
 
-            int fEventID;
+            long int fEventID;
             double fLOFrequency;
             int fRandomSeed;
 
+            std::vector<int> fTrackIDs;
             std::vector<double> fStartingEnergies_eV;
             std::vector<double> fOutputStartFrequencies;
             std::vector<double> fStartFrequencies;

--- a/Source/IO/LMCRootTreeWriter.cc
+++ b/Source/IO/LMCRootTreeWriter.cc
@@ -49,13 +49,14 @@ namespace locust
 
     void RootTreeWriter::WriteEvent(Event* anEvent)
     {
-    	char buffer[100];
-        int n=sprintf(buffer, "Event_%d", anEvent->fEventID);
-    	char* treename = buffer;
+        char buffer[100];
+        int n=sprintf(buffer, "Event_%ld", anEvent->fEventID);
+        char* treename = buffer;
 
         TTree *aTree = new TTree(treename,"Locust Tree");
-        aTree->Branch("EventID", &anEvent->fEventID, "EventID/I");
+        aTree->Branch("EventID", &anEvent->fEventID, "EventID/L");
         aTree->Branch("ntracks", &anEvent->fNTracks, "ntracks/I");
+        aTree->Branch("TrackIDs", "std::vector<int>", &anEvent->fTrackIDs);
         aTree->Branch("StartingEnergieseV", "std::vector<double>", &anEvent->fStartingEnergies_eV);
         aTree->Branch("OutputStartFrequencies", "std::vector<double>", &anEvent->fOutputStartFrequencies);
         aTree->Branch("StartFrequencies", "std::vector<double>", &anEvent->fStartFrequencies);

--- a/Source/IO/LMCTrack.cc
+++ b/Source/IO/LMCTrack.cc
@@ -12,7 +12,8 @@ ClassImp(locust::Track);
 namespace locust
 {
 
-    Track::Track()
+    Track::Track() :
+        TrackID( -2 )
     {
     }
 
@@ -22,7 +23,7 @@ namespace locust
 
     bool Track::Initialize()
     {
-        EventID = -99;
+        TrackID += 1;
         RandomSeed = -99.;
         StartTime = -99.;
         EndTime = -99.;

--- a/Source/IO/LMCTrack.hh
+++ b/Source/IO/LMCTrack.hh
@@ -29,7 +29,7 @@ namespace locust
             Track();
             virtual ~Track();
             bool Initialize();
-            int EventID = -99;
+            int TrackID;
             int RandomSeed = -99.;
             double StartTime = -99.;
             double EndTime = -99.;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -70,21 +70,21 @@ namespace locust
     	if (bStart)
     	{
             fStartingIndex = index;
-            fInterface->aTrack.StartTime = tTime;
+            fInterface->aTrack->StartTime = tTime;
             double tX = aFinalParticle.GetPosition().X();
             double tY = aFinalParticle.GetPosition().Y();
-            fInterface->aTrack.Radius = pow(tX*tX + tY*tY, 0.5);
-            fInterface->aTrack.RadialPhase = calcOrbitPhase(tX, tY);
-            fInterface->aTrack.StartingEnergy_eV = LMCConst::kB_eV() / LMCConst::kB() * aFinalParticle.GetKineticEnergy();
+            fInterface->aTrack->Radius = pow(tX*tX + tY*tY, 0.5);
+            fInterface->aTrack->RadialPhase = calcOrbitPhase(tX, tY);
+            fInterface->aTrack->StartingEnergy_eV = LMCConst::kB_eV() / LMCConst::kB() * aFinalParticle.GetKineticEnergy();
     	}
     	else
     	{
-            fInterface->aTrack.EndTime = tTime;
+            fInterface->aTrack->EndTime = tTime;
             unsigned nElapsedSamples = index - fStartingIndex;
-            fInterface->aTrack.AvgFrequency = ( fInterface->aTrack.AvgFrequency * nElapsedSamples + aFinalParticle.GetCyclotronFrequency() ) / ( nElapsedSamples + 1);
-            fInterface->aTrack.OutputAvgFrequency = fInterface->aTrack.AvgFrequency + tOffset;
-            fInterface->aTrack.TrackLength = tTime - fInterface->aTrack.StartTime;
-            fInterface->aTrack.Slope = (fInterface->aTrack.EndFrequency - fInterface->aTrack.StartFrequency) / (fInterface->aTrack.TrackLength);
+            fInterface->aTrack->AvgFrequency = ( fInterface->aTrack->AvgFrequency * nElapsedSamples + aFinalParticle.GetCyclotronFrequency() ) / ( nElapsedSamples + 1);
+            fInterface->aTrack->OutputAvgFrequency = fInterface->aTrack->AvgFrequency + tOffset;
+            fInterface->aTrack->TrackLength = tTime - fInterface->aTrack->StartTime;
+            fInterface->aTrack->Slope = (fInterface->aTrack->EndFrequency - fInterface->aTrack->StartFrequency) / (fInterface->aTrack->TrackLength);
     	}
 #endif
 
@@ -145,20 +145,20 @@ namespace locust
                 fPitchAngle = aFinalParticle.GetPolarAngleToB();
                 fT0trapMin = aFinalParticle.GetTime();
 #ifdef ROOT_FOUND
-                fInterface->aTrack.PitchAngle = aFinalParticle.GetPolarAngleToB();
-                fInterface->aTrack.StartFrequency = aFinalParticle.GetCyclotronFrequency();
+                fInterface->aTrack->PitchAngle = aFinalParticle.GetPolarAngleToB();
+                fInterface->aTrack->StartFrequency = aFinalParticle.GetCyclotronFrequency();
                 double tLOfrequency = fInterface->aRunParameter->fLOfrequency; // Hz
                 double tSamplingRate = fInterface->aRunParameter->fSamplingRateMHz; // MHz
-                fInterface->aTrack.LOFrequency = tLOfrequency;
-                fInterface->aTrack.RandomSeed = fInterface->aRunParameter->fRandomSeed;
-                fInterface->aTrack.OutputStartFrequency = fInterface->aTrack.StartFrequency - tLOfrequency + tSamplingRate * 1.e6 / 2.;
+                fInterface->aTrack->LOFrequency = tLOfrequency;
+                fInterface->aTrack->RandomSeed = fInterface->aRunParameter->fRandomSeed;
+                fInterface->aTrack->OutputStartFrequency = fInterface->aTrack->StartFrequency - tLOfrequency + tSamplingRate * 1.e6 / 2.;
 #endif
             }
             else
             {
 #ifdef ROOT_FOUND
-                fInterface->aTrack.EndFrequency = aFinalParticle.GetCyclotronFrequency();
-                fInterface->aTrack.AvgAxialFrequency = fNCrossings / 2. / ( aFinalParticle.GetTime() - fT0trapMin );
+                fInterface->aTrack->EndFrequency = aFinalParticle.GetCyclotronFrequency();
+                fInterface->aTrack->AvgAxialFrequency = fNCrossings / 2. / ( aFinalParticle.GetTime() - fT0trapMin );
 #endif
             }
         }

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -41,7 +41,6 @@ namespace locust
 
     bool EventHold::ConfigureByInterface()
     {
-        OpenEvent();
 
         if (!fConfigurationComplete)
         {
@@ -93,11 +92,9 @@ namespace locust
     {
 #ifdef ROOT_FOUND
         fInterface->anEvent = new Event();
-        fInterface->anEvent->fEventID = 0;
-        fInterface->anEvent->fRandomSeed = -99;
-        fInterface->anEvent->fLOFrequency = -99.;
-        fInterface->anEvent->fRandomSeed = -99;
-        fInterface->aTrack.Initialize();
+        fInterface->anEvent->Initialize();
+        fInterface->aTrack = new Track();
+        fInterface->aTrack->Initialize();
 #endif
 
         return true;
@@ -152,6 +149,8 @@ namespace locust
     	    return false;
     	}
 
+        OpenEvent(); // for recording event properties to file.
+
         LPROG( lmclog, "Kass is waiting for event trigger" );
 
         fInterface->fDigitizerCondition.notify_one();  // unlock if still locked.
@@ -180,6 +179,8 @@ namespace locust
         fInterface->fEventInProgress = false;
         fInterface->fDigitizerCondition.notify_one();  // unlock
         LPROG( lmclog, "Kass is waking after event" );
+        delete fInterface->anEvent;
+        delete fInterface->aTrack;
         return true;
     }
 

--- a/Source/Kassiopeia/LMCKassLocustInterface.hh
+++ b/Source/Kassiopeia/LMCKassLocustInterface.hh
@@ -75,7 +75,7 @@ namespace locust
 
 #ifdef ROOT_FOUND
         Event* anEvent;
-        Track aTrack;
+        Track* aTrack;
         RunParameters* aRunParameter;
 #endif
 

--- a/Source/Kassiopeia/LMCTrackHold.cc
+++ b/Source/Kassiopeia/LMCTrackHold.cc
@@ -63,7 +63,7 @@ namespace locust
 
     bool TrackHold::ExecutePreTrackModification(Kassiopeia::KSTrack &aTrack)
     {
-        fInterface->aTrack.Initialize();
+        fInterface->aTrack->Initialize();
         fInterface->fNewTrackStarting = true;
         double tTime = aTrack.GetInitialParticle().GetTime();
 


### PR DESCRIPTION
These changes are a starting point for event identification using a unique integer.  The present format of the integer is [1][day][month][year][microseconds].  It is written to a Root TTree after the event has finished.  A branch of the TTree contains a vector of the track indices 0->ntracks for the event.
![image](https://github.com/user-attachments/assets/c5d52bac-8154-4121-a5ef-34752e5b719b)
