### PR TITLE
Feature/update parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.1 )
+cmake_minimum_required( VERSION 3.2 )
 
 #########
 # setup #
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.1 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 3.1.0)
+project( locust_mc VERSION 3.2.0)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Applications/Testing/testLMCCavity.cc
+++ b/Source/Applications/Testing/testLMCCavity.cc
@@ -172,13 +172,14 @@ TEST_CASE( "testLMCCavity with default parameter values (pass)", "[single-file]"
 	int l = the_main.GetL();
 	int m = the_main.GetM();
 	int n = the_main.GetN();
+	int nModes = 2;
 	bool bTE = the_main.GetbTE();
 	bool checkCavityQ;
 
 	if ( (l<2) && (m<2) && (n<2) )
 	{
 
-	    checkCavityQ = aCavityUtility.CheckCavityQ( bTE, l, m, n, the_main.GetDHOTimeResolution(), the_main.GetDHOThresholdFactor(), the_main.GetCavityFrequency(), the_main.GetCavityQ() );
+	    checkCavityQ = aCavityUtility.CheckCavityQ( nModes, bTE, l, m, n, the_main.GetDHOTimeResolution(), the_main.GetDHOThresholdFactor(), the_main.GetCavityFrequency(), the_main.GetCavityQ() );
 	    REQUIRE( checkCavityQ );
 	}
 	else

--- a/Source/Fields/LMCCylindricalCavity.cc
+++ b/Source/Fields/LMCCylindricalCavity.cc
@@ -19,12 +19,10 @@ namespace locust
         fCavityProbeRFrac( {0.5, 0.5, 0.5} ),
         fCavityProbeTheta( {0.0, 0.0, 0.0} ),
         fCaterpillarCavity( false ),
-        fApplyDopplerShift( true )
+        fApplyDopplerShift( false )
         {}
 
     CylindricalCavity::~CylindricalCavity() {}
-
-
 
     bool CylindricalCavity::Configure( const scarab::param_node& aParam)
     {

--- a/Source/Fields/LMCField.cc
+++ b/Source/Fields/LMCField.cc
@@ -19,7 +19,7 @@ namespace locust
         fNChannels( 1 ),
         fbMultiMode( false ),
         fTM111( false ),
-		fTE012( false ),
+        fTE012( false ),
         fR( 0.18 ),
         fL( 3.0 ),
         fX( 0.010668 ),

--- a/Source/Fields/LMCField.cc
+++ b/Source/Fields/LMCField.cc
@@ -19,6 +19,7 @@ namespace locust
         fNChannels( 1 ),
         fbMultiMode( false ),
         fTM111( false ),
+		fTE012( false ),
         fR( 0.18 ),
         fL( 3.0 ),
         fX( 0.010668 ),
@@ -56,7 +57,13 @@ namespace locust
         	fTM111 = aParam["tm111-mode"]().as_bool();
         }
 
-    	if( aParam.has( "n-pixels" ) )
+        if( aParam.has( "te012-mode" ) )
+        {
+            LPROG(lmclog,"Running with TE012 only.");
+            fTE012 = aParam["te012-mode"]().as_bool();
+        }
+
+        if( aParam.has( "n-pixels" ) )
     	{
     		SetNPixels(aParam["n-pixels"]().as_int());
     	}
@@ -111,6 +118,10 @@ namespace locust
     	    	    if ( fTM111 )
     	    	    {
     	    	        tModeSet.push_back( {0,1,1,1} );
+    	    	    }
+    	    	    else if ( fTE012 )
+    	    	    {
+    	    	        tModeSet.push_back( {1,0,1,2} );
     	    	    }
     	    	    else
     	    	    {

--- a/Source/Fields/LMCField.cc
+++ b/Source/Fields/LMCField.cc
@@ -59,9 +59,16 @@ namespace locust
 
         if( aParam.has( "te012-mode" ) )
         {
-            LPROG(lmclog,"Running with TE012 only.");
+            LPROG(lmclog,"Running with TE012 only.  Set parameter n-modes = 3");
             fTE012 = aParam["te012-mode"]().as_bool();
         }
+
+        if( aParam.has( "te013-mode" ) )
+        {
+            LPROG(lmclog,"Running with TE013 only.  Set parameter n-modes = 4");
+            fTE013 = aParam["te013-mode"]().as_bool();
+        }
+
 
         if( aParam.has( "n-pixels" ) )
     	{
@@ -122,6 +129,10 @@ namespace locust
     	    	    else if ( fTE012 )
     	    	    {
     	    	        tModeSet.push_back( {1,0,1,2} );
+    	    	    }
+    	    	    else if ( fTE013 )
+    	    	    {
+    	    	    	tModeSet.push_back( {1,0,1,3} );
     	    	    }
     	    	    else
     	    	    {

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -148,6 +148,7 @@ namespace locust
             std::string fOutputPath;
             bool fbMultiMode;
             bool fTM111;
+            bool fTE012;
 
 
     };

--- a/Source/Fields/LMCField.hh
+++ b/Source/Fields/LMCField.hh
@@ -149,6 +149,7 @@ namespace locust
             bool fbMultiMode;
             bool fTM111;
             bool fTE012;
+            bool fTE013;
 
 
     };

--- a/Source/Fields/LMCRectangularCavity.cc
+++ b/Source/Fields/LMCRectangularCavity.cc
@@ -13,10 +13,11 @@ namespace locust
 
     LOGGER( lmclog, "RectangularCavity" );
     RectangularCavity::RectangularCavity():
-    	fProbeGain( {1., 1.}),
-		fCavityProbeZ( {0., 0.} ),
-		fCavityProbeRFrac( {0.5, 0.5} ),
-		fCavityProbeTheta( {0.0, 0.0} )
+        fProbeGain( {1., 1.}),
+        fCavityProbeZ( {0., 0.} ),
+        fCavityProbeRFrac( {0.5, 0.5} ),
+        fCavityProbeTheta( {0.0, 0.0} ),
+        fApplyDopplerShift( false )
 		{}
 
     RectangularCavity::~RectangularCavity() {}
@@ -31,6 +32,11 @@ namespace locust
     		LERROR(lmclog,"Error configuring Field class from RectangularCavity subclass");
     		return false;
     	}
+
+        if( aParam.has( "apply-doppler-shift" ) )
+        {
+            fApplyDopplerShift = aParam["apply-doppler-shift"]().as_bool();
+        }
 
         if( aParam.has( "cavity-x" ) )
         {
@@ -196,7 +202,7 @@ namespace locust
     	double lambda = 1. / sqrt( 1. / lambda_c / lambda_c + n*n / 4. / GetDimL() / GetDimL() );
     	double vp = LMCConst::C() * sqrt( 1. - lambda*lambda / lambda_c/lambda_c );
     	double dopplerShift = 0.;
-    	if (vp > 0.) dopplerShift = vz / vp;
+    	if ((vp > 0.) && (fApplyDopplerShift)) dopplerShift = vz / vp;
 		freqPrime.push_back( ( 1. + dopplerShift ) * tKassParticleXP[7] );
 
     	return freqPrime;

--- a/Source/Fields/LMCRectangularCavity.hh
+++ b/Source/Fields/LMCRectangularCavity.hh
@@ -73,6 +73,8 @@ namespace locust
             std::vector<double> fCavityProbeRFrac;
             std::vector<double> fCavityProbeTheta;
             std::vector<double> fProbeGain;
+            bool fApplyDopplerShift;
+
 
     };
 

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -397,7 +397,8 @@ namespace locust
             cavityFrequency = fAnalyticResponseFunction->GetCavityFrequency(bTE, l, m, n);
             qExpected = fAnalyticResponseFunction->GetCavityQ(bTE, l, m, n);
             aCavityUtility.SetOutputFile(fUnitTestRootFile);
-            if (!aCavityUtility.CheckCavityQ( bTE, l, m, n, timeResolution, thresholdFactor, cavityFrequency, qExpected ))
+            int nModes = fInterface->fField->GetNModes();
+            if (!aCavityUtility.CheckCavityQ( nModes, bTE, l, m, n, timeResolution, thresholdFactor, cavityFrequency, qExpected ))
             {
                 LERROR(lmclog,"The cavity Q does not look quite right.  Please tune the configuration "
                 		"with the unit test as in bin/testLMCCavity [-h]");

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -216,6 +216,9 @@ namespace locust
             ost << "         {\n";
             ost << "             \"start-time\": "<< "\"" << fInterface->anEvent->fStartTimes[i] << "\",\n";
             ost << "             \"end-time\": "<< "\"" << fInterface->anEvent->fEndTimes[i] << "\",\n";
+            ost << "             \"energy-ev\": "<< "\"" << fInterface->anEvent->fStartingEnergies_eV[i] << "\",\n";
+            ost << "             \"start-radius\": "<< "\"" << fInterface->anEvent->fRadii[i] << "\",\n";
+            ost << "             \"start-radial-phase\": "<< "\"" << fInterface->anEvent->fRadialPhases[i] << "\",\n";
             ost << "             \"output-avg-frequency\": "<< "\"" << fInterface->anEvent->fOutputAvgFrequencies[i] << "\",\n";
             ost << "             \"pitch-angle\": "<< "\"" << fInterface->anEvent->fPitchAngles[i] << "\",\n";
             ost << "             \"avg-axial-frequency\": "<< "\"" << fInterface->anEvent->fAvgAxialFrequencies[i] << "\"\n";

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -188,6 +188,7 @@ namespace locust
             ost << "        \"simulation-type\": "<< "\"" << fInterface->aRunParameter->fSimulationType << "\",\n";
             ost << "        \"simulation-subtype\": "<< "\"" << fInterface->aRunParameter->fSimulationSubType << "\",\n";
             ost << "        \"sampling-freq-mega-hz\": "<< "\"" << fInterface->aRunParameter->fSamplingRateMHz << "\"\n";
+            ost << "        \"random-seed\": "<< "\"" << fEventSeed << "\"\n";
             ost << "    },\n";
         }
         else // otherwise re-write the file:

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -21,6 +21,9 @@ namespace locust
             fAccumulateTruthInfo( false ),
             fConfigurationComplete( false ),
             fEventSeed( 0 ),
+            fConfiguredEMin( 0. ),
+            fConfiguredPitchMin( 0. ),
+            fConfiguredXMin( 0. ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     }
@@ -30,6 +33,9 @@ namespace locust
             fAccumulateTruthInfo( false ),
             fConfigurationComplete( false ),
             fEventSeed( 0 ),
+            fConfiguredEMin( 0. ),
+            fConfiguredPitchMin( 0. ),
+            fConfiguredXMin( 0. ),
             fInterface( aOrig.fInterface )
     {
     }
@@ -88,6 +94,18 @@ namespace locust
 	    if ( aParam.has( "accumulate-truth-info" ) )
 	    {
 	    	fAccumulateTruthInfo = aParam["accumulate-truth-info"]().as_bool();
+	    }
+	    if ( aParam.has( "ks-starting-energy-min" ) )
+	    {
+	        fConfiguredEMin = aParam["ks-starting-energy-min"]().as_double();
+	    }
+	    if ( aParam.has( "ks-starting-pitch-min" ) )
+	    {
+	        fConfiguredPitchMin = aParam["ks-starting-pitch-min"]().as_double();
+	    }
+	    if ( aParam.has( "ks-starting-xpos-min" ) )
+	    {
+	    	fConfiguredXMin = aParam["ks-starting-xpos-min"]().as_double();
 	    }
 
 
@@ -175,21 +193,24 @@ namespace locust
             LPROG( lmclog, "A json file for meta-data was not found.  Opening a new one now." );
         }
 
-        std::ofstream ost {fJsonFileName, std::ios_base::out};
+        FILE *file = std::fopen(fJsonFileName.c_str(), "w");
 
 
 #ifdef ROOT_FOUND
         if (bNewRun)  // If there are no run parameters in the json file yet, write them now:
         {
-            ost << "{\n";
-            ost << "    \"run-id\": "<< "\"" << fInterface->aRunParameter->fRunID << "\",\n";
-            ost << "    \"run-parameters\": {\n";
-            ost << "        \"run-type\": "<< "\"" << fInterface->aRunParameter->fDataType << "\",\n";
-            ost << "        \"simulation-type\": "<< "\"" << fInterface->aRunParameter->fSimulationType << "\",\n";
-            ost << "        \"simulation-subtype\": "<< "\"" << fInterface->aRunParameter->fSimulationSubType << "\",\n";
-            ost << "        \"sampling-freq-mega-hz\": "<< "\"" << fInterface->aRunParameter->fSamplingRateMHz << "\"\n";
-            ost << "        \"random-seed\": "<< "\"" << fEventSeed << "\"\n";
-            ost << "    },\n";
+            fprintf(file, "{\n");
+            fprintf(file, "    \"run-id\": \"%ld\",\n", fInterface->aRunParameter->fRunID);
+            fprintf(file, "    \"run-parameters\": {\n");
+            fprintf(file, "        \"run-type\": \"%s\",\n", fInterface->aRunParameter->fDataType.c_str());
+            fprintf(file, "        \"simulation-type\": \"%s\",\n", fInterface->aRunParameter->fSimulationType.c_str());
+            fprintf(file, "        \"simulation-subtype\": \"%s\",\n", fInterface->aRunParameter->fSimulationSubType.c_str());
+            fprintf(file, "        \"sampling-freq-mega-hz\": \"%.1f\",\n", fInterface->aRunParameter->fSamplingRateMHz);
+            fprintf(file, "        \"configured-e-min\": \"%12.6f\",\n", fConfiguredEMin);
+            fprintf(file, "        \"configured-pitch-min\": \"%10.7f\",\n", fConfiguredPitchMin);
+            fprintf(file, "        \"configured-x-min\": \"%9.7f\",\n", fConfiguredXMin);
+            fprintf(file, "        \"random-seed\": \"%ld\"\n", fEventSeed);
+            fprintf(file, "    },\n");
         }
         else // otherwise re-write the file:
         {
@@ -197,11 +218,11 @@ namespace locust
             {
                 if (i < v.size()-1)
                 {
-                    ost << v[i] << "\n";
+                    fprintf(file,"%s\n", v[i].c_str());
                 }
                 else
                 {
-                    ost << v[i] << ",\n";
+                    fprintf(file,"%s,\n", v[i].c_str());
                 }
             }
         }
@@ -209,33 +230,34 @@ namespace locust
 
         // Write the latest event information here:
 
-        ost << "    \"" << fInterface->anEvent->fEventID << "\": {\n";
-        ost << "        \"ntracks\": "<< "\"" << fInterface->anEvent->fNTracks << "\",\n";
+        fprintf(file,"    \"%ld\": {\n", fInterface->anEvent->fEventID);
+        fprintf(file,"        \"ntracks\": \"%d\",\n", fInterface->anEvent->fNTracks);
         for (int i=0; i<fInterface->anEvent->fNTracks; i++)
         {
-            ost << "        \"" << fInterface->anEvent->fTrackIDs[i] << "\":\n";
-            ost << "         {\n";
-            ost << "             \"start-time\": "<< "\"" << fInterface->anEvent->fStartTimes[i] << "\",\n";
-            ost << "             \"end-time\": "<< "\"" << fInterface->anEvent->fEndTimes[i] << "\",\n";
-            ost << "             \"energy-ev\": "<< "\"" << fInterface->anEvent->fStartingEnergies_eV[i] << "\",\n";
-            ost << "             \"start-radius\": "<< "\"" << fInterface->anEvent->fRadii[i] << "\",\n";
-            ost << "             \"start-radial-phase\": "<< "\"" << fInterface->anEvent->fRadialPhases[i] << "\",\n";
-            ost << "             \"output-avg-frequency\": "<< "\"" << fInterface->anEvent->fOutputAvgFrequencies[i] << "\",\n";
-            ost << "             \"pitch-angle\": "<< "\"" << fInterface->anEvent->fPitchAngles[i] << "\",\n";
-            ost << "             \"avg-axial-frequency\": "<< "\"" << fInterface->anEvent->fAvgAxialFrequencies[i] << "\"\n";
+            fprintf(file,"        \"%d\":\n", fInterface->anEvent->fTrackIDs[i]);
+            fprintf(file,"         {\n");
+            fprintf(file,"             \"start-time\": \"%g\",\n", fInterface->anEvent->fStartTimes[i]);
+            fprintf(file,"             \"end-time\": \"%g\",\n", fInterface->anEvent->fEndTimes[i]);
+            fprintf(file,"             \"energy-ev\": \"%g\",\n", fInterface->anEvent->fStartingEnergies_eV[i]);
+            fprintf(file,"             \"start-radius\": \"%g\",\n", fInterface->anEvent->fRadii[i]);
+            fprintf(file,"             \"start-radial-phase\": \"%g\",\n", fInterface->anEvent->fRadialPhases[i]);
+            fprintf(file,"             \"output-avg-frequency\": \"%g\",\n", fInterface->anEvent->fOutputAvgFrequencies[i]);
+            fprintf(file,"             \"pitch-angle\": \"%.2f\",\n", fInterface->anEvent->fPitchAngles[i]);
+            fprintf(file,"             \"avg-axial-frequency\": \"%g\"\n", fInterface->anEvent->fAvgAxialFrequencies[i]);
             if (i < fInterface->anEvent->fNTracks-1)
             {
-                ost << "         },\n";
+                fprintf(file,"         },\n");
             }
             else
             {
-            	ost << "         }\n";
+            	fprintf(file,"         }\n");
             }
         }
-        ost << "    }\n";
-        ost << "}\n";
+        fprintf(file,"    }\n");
+        fprintf(file,"}\n");
 
 #endif
+        std::fclose(file);
 
         return true;
     }

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -53,6 +53,9 @@ namespace locust
         private:
             bool fConfigurationComplete;
             long int fEventSeed;
+            double fConfiguredEMin;
+            double fConfiguredPitchMin;
+            double fConfiguredXMin;
 
     };
 

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -232,19 +232,21 @@ namespace locust
         double norm = 0.;
         double coupling = 0.;
         double dimR = fInterface->fField->GetDimR(); // m
+        double dimZ = fInterface->fField->GetDimL(); // m
         double x = aFinalParticle.GetPosition().GetX();
         double y = aFinalParticle.GetPosition().GetY();
         double z = aFinalParticle.GetPosition().GetZ();
         double r = pow( x*x + y*y, 0.5 );
+        double tZ = dimZ/2. - dimZ/2./n;  // Normalize in an antinode along z
 
         if (bTE)
         {
-    	    norm = fInterface->fField->GetTE_E(l,m,n,dimR/2.,0.,0.,false).back(); // max value, TO-DO:  make more general?
+    	    norm = fInterface->fField->GetTE_E(l,m,n,dimR/2.,0.,tZ,false).back(); // max value, TO-DO:  make more general?
     	    coupling = tAvgDotProductFactor * fInterface->fField->GetTE_E(l,m,n,r,0.,z,false).back()/norm;
         }
         else
         {
-            norm = fInterface->fField->GetTM_E(l,m,n,dimR/2.,0.,0.,false).back(); // TO-DO:  decide coordinates
+            norm = fInterface->fField->GetTM_E(l,m,n,dimR/2.,0.,tZ,false).back(); // TO-DO:  decide coordinates
             coupling = tAvgDotProductFactor * fInterface->fField->GetTM_E(l,m,n,r,0.,z,false).back()/norm;
         }
 

--- a/Source/RxComponents/LMCDampedHarmonicOscillator.cc
+++ b/Source/RxComponents/LMCDampedHarmonicOscillator.cc
@@ -145,8 +145,8 @@ namespace locust
             fBFactor[bTE].resize(nModes);
             fCavityDampingFactor[bTE].resize(nModes);
             fHannekePowerFactor[bTE].resize(nModes);
-            fCavityOmega[bTE].resize(2);
-            fCavityOmegaPrime[bTE].resize(2);
+            fCavityOmega[bTE].resize(nModes);
+            fCavityOmegaPrime[bTE].resize(nModes);
 
             for(int l=0; l<nModes; l++)
             {

--- a/Source/Utilities/LMCCavityUtility.cc
+++ b/Source/Utilities/LMCCavityUtility.cc
@@ -135,12 +135,13 @@ namespace locust
 	}
 
 
-    bool CavityUtility::CheckCavityQ( int bTE, int l, int m, int n, double dhoTimeResolution, double dhoThresholdFactor, double dhoCavityFrequency, double dhoCavityQ)
+    bool CavityUtility::CheckCavityQ( int nModes, int bTE, int l, int m, int n, double dhoTimeResolution, double dhoThresholdFactor, double dhoCavityFrequency, double dhoCavityQ)
     {
     	AddParam( "dho-time-resolution", dhoTimeResolution );
     	AddParam( "dho-threshold-factor", dhoThresholdFactor );
     	AddParam( "dho-cavity-frequency", dhoCavityFrequency );
     	AddParam( "dho-cavity-Q", dhoCavityQ );
+    	AddParam( "n-modes", nModes );
     	if (!Configure(bTE, l, m, n))
     	{
     		LERROR(testlog,"Cavity was not configured correctly.");

--- a/Source/Utilities/LMCCavityUtility.hh
+++ b/Source/Utilities/LMCCavityUtility.hh
@@ -43,7 +43,7 @@ namespace locust
         virtual ~CavityUtility();
 
         bool Configure(int bTE, int l, int m, int n);
-        bool CheckCavityQ( int bTE, int l, int m, int n, double dhoTimeResolution, double dhoThresholdFactor, double dhoCavityFrequency, double dhoCavityQ);
+        bool CheckCavityQ( int nModes, int bTE, int l, int m, int n, double dhoTimeResolution, double dhoThresholdFactor, double dhoCavityFrequency, double dhoCavityQ);
         void SetExpandFactor(double aFactor);
     	void SetOutputFile(bool aFlag);
         void AddParam(std::string aString, double aValue);


### PR DESCRIPTION
With these changes, the cavity Doppler shift has been removed from the default calculations, as discussed [here](https://3.basecamp.com/3700981/buckets/3107037/documents/8305757111#__recording_8305790369).  Minor unrelated updates are also included for running a single higher-order mode.  