### PR TITLE
updates to randomization and metadata format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/microsecondRandomization]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/microsecondRandomization]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.2 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 3.2.1)
+project( locust_mc VERSION 3.2.2)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Generators/LMCArraySignalGenerator.cc
+++ b/Source/Generators/LMCArraySignalGenerator.cc
@@ -360,12 +360,13 @@ namespace locust
     bool ArraySignalGenerator::RecordRunParameters( Signal* aSignal )
     {
 #ifdef ROOT_FOUND
-    	fInterface->aRunParameter = new RunParameters();
-    	fInterface->aRunParameter->fSamplingRateMHz = fAcquisitionRate;
-    	fInterface->aRunParameter->fDecimationFactor = aSignal->DecimationFactor();
-    	fInterface->aRunParameter->fLOfrequency = fLO_Frequency;
+        fInterface->aRunParameter = new RunParameters();
+        fInterface->aRunParameter->fSimulationType = "fscd";
+        fInterface->aRunParameter->fSamplingRateMHz = fAcquisitionRate;
+        fInterface->aRunParameter->fDecimationFactor = aSignal->DecimationFactor();
+        fInterface->aRunParameter->fLOfrequency = fLO_Frequency;
 #endif
-    	return true;
+        return true;
     }
 
 

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -346,13 +346,16 @@ namespace locust
         return true;
     }
 
+    int CavitySignalGenerator::GetSeed()
+    {
+        return fTrackDelaySeed;
+    }
 
     bool CavitySignalGenerator::RandomizeStartDelay()
     {
         scarab::param_node default_setting;
         default_setting.add("name","uniform");
         fStartDelayDistribution = fDistributionInterface.get_dist(default_setting);
-        fDistributionInterface.SetSeed( fTrackDelaySeed );
         int tNPreEventSamples = fNPreEventSamples * fStartDelayDistribution->Generate();
         LPROG(lmclog,"Randomizing the start delay to " << tNPreEventSamples << " fast samples.");
         fNPreEventSamples = tNPreEventSamples;
@@ -411,6 +414,7 @@ namespace locust
 
 #ifdef ROOT_FOUND
             fInterface->aRunParameter = new RunParameters();
+            fInterface->aRunParameter->fTrackDelaySeed = GetSeed();
             fInterface->aRunParameter->fSimulationType = "cavity";
             if ( cavityFrequency > 20.e9 )
             {

--- a/Source/Generators/LMCCavitySignalGenerator.cc
+++ b/Source/Generators/LMCCavitySignalGenerator.cc
@@ -282,22 +282,25 @@ namespace locust
                 {
                     fRandomPreEventSamples = true;
                 }
-        	    if ( aParam.has( "random-track-seed" ) )
-        	    {
-        	    	// Randomize seed for start time using seed for track length as input:
-        	        scarab::param_node default_setting;
-        	        default_setting.add("name","uniform");
-        	        std::shared_ptr< BaseDistribution> tSeedDistribution = fDistributionInterface.get_dist(default_setting);
-        	        fDistributionInterface.SetSeed( aParam["random-track-seed"]().as_int() );
-        	        int tSeed = 1.e8 * tSeedDistribution->Generate();
+                if ( aParam.has( "random-track-seed" ) )
+                {
+                    // Randomize seed for start time using seed for track length as input:
+                    scarab::param_node default_setting;
+                    default_setting.add("name","uniform");
+                    std::shared_ptr< BaseDistribution> tSeedDistribution = fDistributionInterface.get_dist(default_setting);
+                    fDistributionInterface.SetSeed( aParam["random-track-seed"]().as_int() );
+                    int tSeed = 1.e8 * tSeedDistribution->Generate();
+                    SetSeed( tSeed );
+                }
+                else
+                {
+                    // Delay SetSeed to allow time stamp to advance between randomized tracks.
+                    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+                    struct timeval tv;
+                    gettimeofday(&tv, NULL);
+                    int tSeed = tv.tv_usec;
         	        SetSeed( tSeed );
-        	    }
-        	    else
-        	    {
-        	    	// Delay SetSeed to allow time stamp to advance between randomized tracks.
-            		std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-        	    	SetSeed (time(NULL) );
-        	    }
+                }
             }
         }
         if( aParam.has( "override-aliasing" ) )

--- a/Source/Generators/LMCCavitySignalGenerator.hh
+++ b/Source/Generators/LMCCavitySignalGenerator.hh
@@ -88,6 +88,7 @@ namespace locust
             const scarab::param_node* GetParameters();
             void SetParameters( const scarab::param_node& aNode );
             bool SetSeed(int aSeed);
+            int GetSeed();
 
 
 

--- a/Source/IO/LMCEvent.cc
+++ b/Source/IO/LMCEvent.cc
@@ -41,6 +41,29 @@ namespace locust
         fEventID = 1e12 + tDay*1e10 + tMonth*1e8 + tYear*1e6 + tMicrosec;
         fRandomSeed = aSeed;
         fLOFrequency = -99.;
+
+
+        fTrackIDs.resize(0);
+        fStartingEnergies_eV.resize(0);
+        fOutputStartFrequencies.resize(0);
+        fStartFrequencies.resize(0);
+        fEndFrequencies.resize(0);
+        fAvgFrequencies.resize(0);
+        fOutputAvgFrequencies.resize(0);
+        fAvgAxialFrequencies.resize(0);
+        fTrackPowers.resize(0);
+        fStartTimes.resize(0);
+        fTrackLengths.resize(0);
+        fEndTimes.resize(0);
+        fSlopes.resize(0);
+        fPitchAngles.resize(0);
+        fRadii.resize(0);
+        fRadialPhases.resize(0);
+
+        // Update size.
+        fNTracks = 0;
+
+
         return true;
     }
 
@@ -49,7 +72,7 @@ namespace locust
     {
         fTrackIDs.push_back( aTrack->TrackID );
         fStartingEnergies_eV.push_back( aTrack->StartingEnergy_eV );
-    	fOutputStartFrequencies.push_back( aTrack->OutputStartFrequency );
+        fOutputStartFrequencies.push_back( aTrack->OutputStartFrequency );
         fStartFrequencies.push_back( aTrack->StartFrequency );
         fEndFrequencies.push_back( aTrack->EndFrequency );
         fAvgFrequencies.push_back( aTrack->AvgFrequency );

--- a/Source/IO/LMCEvent.cc
+++ b/Source/IO/LMCEvent.cc
@@ -18,12 +18,13 @@ ClassImp(locust::Event);
 namespace locust
 {
     Event::Event() :
-        fNTracks( 0 )
+        fNTracks( 0 ),
+        fRandomSeed( 0 )
     {
     }
     Event::~Event() {}
 
-    bool Event::Initialize(long int aSeed)
+    bool Event::Initialize()
     {
         time_t rawtime;
         struct tm * timeInfo;
@@ -39,7 +40,6 @@ namespace locust
         int tMicrosec = tv.tv_usec;
 
         fEventID = 1e12 + tDay*1e10 + tMonth*1e8 + tYear*1e6 + tMicrosec;
-        fRandomSeed = aSeed;
         fLOFrequency = -99.;
 
 

--- a/Source/IO/LMCEvent.hh
+++ b/Source/IO/LMCEvent.hh
@@ -32,7 +32,7 @@ namespace locust
             Event();
             virtual ~Event();
 
-            bool Initialize(long int aSeed);
+            bool Initialize();
             void AddTrack(const Track* aTrack);
             void AddTrack(const Track aTrack);
 

--- a/Source/IO/LMCRunParameters.cc
+++ b/Source/IO/LMCRunParameters.cc
@@ -25,7 +25,10 @@ namespace locust
 		fDataType( "simulation" ),
 		fSimulationType( "rectangular-waveguide" ),
 		fSimulationSubType( "none" ),
-		fRunID( 0 )
+		fRunID( 0 ),
+		fKassiopeiaSeed( 0 ),
+		fTrackLengthSeed( 0 ),
+		fTrackDelaySeed( 0 )
     {
         time_t rawtime;
         struct tm * timeInfo;

--- a/Source/IO/LMCRunParameters.hh
+++ b/Source/IO/LMCRunParameters.hh
@@ -36,6 +36,9 @@ namespace locust
             std::string fSimulationType;
             std::string fSimulationSubType;
             long int fRunID;
+            int fKassiopeiaSeed;
+            int fTrackLengthSeed;
+            int fTrackDelaySeed;
 
             ClassDef(RunParameters,1)  // Root syntax.
 

--- a/Source/IO/LMCTrack.cc
+++ b/Source/IO/LMCTrack.cc
@@ -23,7 +23,7 @@ namespace locust
 
     bool Track::Initialize()
     {
-        TrackID += 1;
+        TrackID = 0;
         StartTime = -99.;
         EndTime = -99.;
         TrackLength = -99.;

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -80,6 +80,7 @@ namespace locust
             fInterface->aTrack->Radius = pow(tX*tX + tY*tY, 0.5);
             fInterface->aTrack->RadialPhase = calcOrbitPhase(tX, tY);
             fInterface->aTrack->StartingEnergy_eV = LMCConst::kB_eV() / LMCConst::kB() * aFinalParticle.GetKineticEnergy();
+            fInterface->aTrack->OutputStartFrequency = aFinalParticle.GetCyclotronFrequency() + tOffset;
     	}
     	else
     	{
@@ -153,7 +154,6 @@ namespace locust
                 fInterface->aTrack->StartFrequency = aFinalParticle.GetCyclotronFrequency();
                 double tLOfrequency = fInterface->aRunParameter->fLOfrequency; // Hz
                 double tSamplingRate = fInterface->aRunParameter->fSamplingRateMHz; // MHz
-                fInterface->aTrack->OutputStartFrequency = fInterface->aTrack->StartFrequency - tLOfrequency + tSamplingRate * 1.e6 / 2.;
 #endif
             }
             else

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -80,7 +80,6 @@ namespace locust
             fInterface->aTrack->Radius = pow(tX*tX + tY*tY, 0.5);
             fInterface->aTrack->RadialPhase = calcOrbitPhase(tX, tY);
             fInterface->aTrack->StartingEnergy_eV = LMCConst::kB_eV() / LMCConst::kB() * aFinalParticle.GetKineticEnergy();
-            fInterface->aTrack->OutputStartFrequency = aFinalParticle.GetCyclotronFrequency() + tOffset;
     	}
     	else
     	{
@@ -154,6 +153,8 @@ namespace locust
                 fInterface->aTrack->StartFrequency = aFinalParticle.GetCyclotronFrequency();
                 double tLOfrequency = fInterface->aRunParameter->fLOfrequency; // Hz
                 double tSamplingRate = fInterface->aRunParameter->fSamplingRateMHz; // MHz
+                double tOffset = -tLOfrequency + tSamplingRate * 1.e6 / 2.; // Hz
+                fInterface->aTrack->OutputStartFrequency = aFinalParticle.GetCyclotronFrequency() + tOffset; // Hz
 #endif
             }
             else

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -320,7 +320,6 @@ namespace locust
 #ifdef ROOT_FOUND
         delete fInterface->anEvent;
         delete fInterface->aTrack;
-        delete fInterface->aRunParameter;
 #endif
         return true;
     }

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -216,9 +216,9 @@ namespace locust
             fprintf(file, "        \"simulation-subtype\": \"%s\",\n", fInterface->aRunParameter->fSimulationSubType.c_str());
             fprintf(file, "        \"sampling-freq-mega-hz\": \"%.1f\",\n", fInterface->aRunParameter->fSamplingRateMHz);
             fprintf(file, "        \"configured-e-min\": \"%12.6f\",\n", fConfiguredEMin);
-            fprintf(file, "        \"configured-pitch-min\": \"%10.7f\",\n", fConfiguredPitchMin);
-            fprintf(file, "        \"configured-x-min\": \"%9.7f\",\n", fConfiguredXMin);
-            fprintf(file, "        \"configured-y-min\": \"%9.7f\",\n", fConfiguredYMin);
+            fprintf(file, "        \"configured-pitch-min\": \"%12.9f\",\n", fConfiguredPitchMin);
+            fprintf(file, "        \"configured-x-min\": \"%11.9f\",\n", fConfiguredXMin);
+            fprintf(file, "        \"configured-y-min\": \"%11.9f\",\n", fConfiguredYMin);
             fprintf(file, "        \"random-seed\": \"%ld\"\n", fEventSeed);
             fprintf(file, "    },\n");
             fprintf(file, "    \"nevents\": %d\n", fEventCounter+1);
@@ -261,7 +261,7 @@ namespace locust
             fprintf(file,"             \"start-radius\": %g,\n", fInterface->anEvent->fRadii[i]);
             fprintf(file,"             \"start-radial-phase\": %g,\n", fInterface->anEvent->fRadialPhases[i]);
             fprintf(file,"             \"output-avg-frequency\": %g,\n", fInterface->anEvent->fOutputAvgFrequencies[i]);
-            fprintf(file,"             \"pitch-angle\": %.2f,\n", fInterface->anEvent->fPitchAngles[i]);
+            fprintf(file,"             \"pitch-angle\": %.6f,\n", fInterface->anEvent->fPitchAngles[i]);
             fprintf(file,"             \"avg-axial-frequency\": %g\n", fInterface->anEvent->fAvgAxialFrequencies[i]);
             if (i < fInterface->anEvent->fNTracks-1)
             {

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -24,6 +24,7 @@ namespace locust
             fConfiguredEMin( 0. ),
             fConfiguredPitchMin( 0. ),
             fConfiguredXMin( 0. ),
+            fEventCounter ( 0 ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
     }
@@ -197,6 +198,7 @@ namespace locust
 
 
 #ifdef ROOT_FOUND
+        fEventCounter = 0;
         if (bNewRun)  // If there are no run parameters in the json file yet, write them now:
         {
             fprintf(file, "{\n");
@@ -216,6 +218,8 @@ namespace locust
         {
             for (int i = 0; i < v.size(); i++)
             {
+                //increment the event counter
+                if ( v[i].find("\"event-tag\"") != std::string::npos ) fEventCounter += 1;
                 if (i < v.size()-1)
                 {
                     fprintf(file,"%s\n", v[i].c_str());
@@ -230,7 +234,8 @@ namespace locust
 
         // Write the latest event information here:
 
-        fprintf(file,"    \"%ld\": {\n", fInterface->anEvent->fEventID);
+        fprintf(file,"    \"%d\": {\n", fEventCounter);
+        fprintf(file,"        \"event-tag\": \"%ld\",\n", fInterface->anEvent->fEventID);
         fprintf(file,"        \"ntracks\": \"%d\",\n", fInterface->anEvent->fNTracks);
         for (int i=0; i<fInterface->anEvent->fNTracks; i++)
         {

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -214,7 +214,7 @@ namespace locust
             fprintf(file, "        \"configured-x-min\": \"%9.7f\",\n", fConfiguredXMin);
             fprintf(file, "        \"random-seed\": \"%ld\"\n", fEventSeed);
             fprintf(file, "    },\n");
-            fprintf(file, "    \"nevents\": %d\n", fEventCounter);
+            fprintf(file, "    \"nevents\": %d\n", fEventCounter+1);
         }
         else // otherwise re-write the file:
         {

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -24,6 +24,7 @@ namespace locust
             fConfiguredEMin( 0. ),
             fConfiguredPitchMin( 0. ),
             fConfiguredXMin( 0. ),
+            fConfiguredYMin( 0. ),
             fEventCounter ( 0 ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
@@ -37,6 +38,7 @@ namespace locust
             fConfiguredEMin( 0. ),
             fConfiguredPitchMin( 0. ),
             fConfiguredXMin( 0. ),
+            fConfiguredYMin( 0. ),
             fInterface( aOrig.fInterface )
     {
     }
@@ -107,6 +109,10 @@ namespace locust
 	    if ( aParam.has( "ks-starting-xpos-min" ) )
 	    {
 	    	fConfiguredXMin = aParam["ks-starting-xpos-min"]().as_double();
+	    }
+	    if ( aParam.has( "ks-starting-ypos-min" ) )
+	    {
+	    	fConfiguredYMin = aParam["ks-starting-ypos-min"]().as_double();
 	    }
 
 
@@ -212,6 +218,7 @@ namespace locust
             fprintf(file, "        \"configured-e-min\": \"%12.6f\",\n", fConfiguredEMin);
             fprintf(file, "        \"configured-pitch-min\": \"%10.7f\",\n", fConfiguredPitchMin);
             fprintf(file, "        \"configured-x-min\": \"%9.7f\",\n", fConfiguredXMin);
+            fprintf(file, "        \"configured-y-min\": \"%9.7f\",\n", fConfiguredYMin);
             fprintf(file, "        \"random-seed\": \"%ld\"\n", fEventSeed);
             fprintf(file, "    },\n");
             fprintf(file, "    \"nevents\": %d\n", fEventCounter+1);

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -125,7 +125,7 @@ namespace locust
     {
 #ifdef ROOT_FOUND
         fInterface->anEvent = new Event();
-        fInterface->anEvent->Initialize( fEventSeed );
+        fInterface->anEvent->Initialize();
         fInterface->aTrack = new Track();
         fInterface->aTrack->Initialize();
 #endif
@@ -219,7 +219,6 @@ namespace locust
             fprintf(file, "        \"configured-pitch-min\": \"%12.9f\",\n", fConfiguredPitchMin);
             fprintf(file, "        \"configured-x-min\": \"%11.9f\",\n", fConfiguredXMin);
             fprintf(file, "        \"configured-y-min\": \"%11.9f\",\n", fConfiguredYMin);
-            fprintf(file, "        \"random-seed\": \"%ld\"\n", fEventSeed);
             fprintf(file, "    },\n");
             fprintf(file, "    \"nevents\": %d\n", fEventCounter+1);
         }
@@ -250,6 +249,9 @@ namespace locust
 
         fprintf(file,"    \"%d\": {\n", fEventCounter);
         fprintf(file,"        \"event-tag\": \"%ld\",\n", fInterface->anEvent->fEventID);
+        fprintf(file,"        \"kassiopeia-seed\": %d\n", fInterface->aRunParameter->fKassiopeiaSeed);
+        fprintf(file,"        \"track-length-seed\": %d\n", fInterface->aRunParameter->fTrackLengthSeed);
+        fprintf(file,"        \"track-delay-seed\": %d\n", fInterface->aRunParameter->fTrackDelaySeed);
         fprintf(file,"        \"ntracks\": %d,\n", fInterface->anEvent->fNTracks);
         for (int i=0; i<fInterface->anEvent->fNTracks; i++)
         {

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -261,6 +261,7 @@ namespace locust
             fprintf(file,"             \"start-radius\": %g,\n", fInterface->anEvent->fRadii[i]);
             fprintf(file,"             \"start-radial-phase\": %g,\n", fInterface->anEvent->fRadialPhases[i]);
             fprintf(file,"             \"output-avg-frequency\": %g,\n", fInterface->anEvent->fOutputAvgFrequencies[i]);
+            fprintf(file,"             \"output-inst-start-frequency\": %g,\n", fInterface->anEvent->fOutputStartFrequencies[i]);
             fprintf(file,"             \"pitch-angle\": %.6f,\n", fInterface->anEvent->fPitchAngles[i]);
             fprintf(file,"             \"avg-axial-frequency\": %g\n", fInterface->anEvent->fAvgAxialFrequencies[i]);
             if (i < fInterface->anEvent->fNTracks-1)

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -174,14 +174,16 @@ namespace locust
     {
         std::ifstream jsonFile(fJsonFileName); // Open json file for inspection
         bool bNewRun = true;
+        fEventCounter = 0;
         std::vector<std::string> v;
         if (jsonFile.is_open())
         {
             std::string line;
             while (std::getline(jsonFile, line))
             {
-                LPROG( lmclog, line );
                 bNewRun = !line.find("run-id");
+                //increment the event counter
+                if ( line.find("\"event-tag\"") != std::string::npos ) fEventCounter += 1;
                 if (line != "}")  // Avoid saving the last "}".  It will be appended below.
                 {
                     v.push_back(line);
@@ -198,7 +200,6 @@ namespace locust
 
 
 #ifdef ROOT_FOUND
-        fEventCounter = 0;
         if (bNewRun)  // If there are no run parameters in the json file yet, write them now:
         {
             fprintf(file, "{\n");
@@ -213,16 +214,22 @@ namespace locust
             fprintf(file, "        \"configured-x-min\": \"%9.7f\",\n", fConfiguredXMin);
             fprintf(file, "        \"random-seed\": \"%ld\"\n", fEventSeed);
             fprintf(file, "    },\n");
+            fprintf(file, "    \"nevents\": %d\n", fEventCounter);
         }
         else // otherwise re-write the file:
         {
             for (int i = 0; i < v.size(); i++)
             {
-                //increment the event counter
-                if ( v[i].find("\"event-tag\"") != std::string::npos ) fEventCounter += 1;
                 if (i < v.size()-1)
                 {
-                    fprintf(file,"%s\n", v[i].c_str());
+                    if ( v[i].find("\"nevents\"") != std::string::npos )
+                    {
+                    	fprintf(file, "    \"nevents\": %d,\n", fEventCounter+1);
+                    }
+                    else
+                    {
+                        fprintf(file,"%s\n", v[i].c_str());
+                    }
                 }
                 else
                 {
@@ -236,19 +243,19 @@ namespace locust
 
         fprintf(file,"    \"%d\": {\n", fEventCounter);
         fprintf(file,"        \"event-tag\": \"%ld\",\n", fInterface->anEvent->fEventID);
-        fprintf(file,"        \"ntracks\": \"%d\",\n", fInterface->anEvent->fNTracks);
+        fprintf(file,"        \"ntracks\": %d,\n", fInterface->anEvent->fNTracks);
         for (int i=0; i<fInterface->anEvent->fNTracks; i++)
         {
             fprintf(file,"        \"%d\":\n", fInterface->anEvent->fTrackIDs[i]);
             fprintf(file,"         {\n");
-            fprintf(file,"             \"start-time\": \"%g\",\n", fInterface->anEvent->fStartTimes[i]);
-            fprintf(file,"             \"end-time\": \"%g\",\n", fInterface->anEvent->fEndTimes[i]);
-            fprintf(file,"             \"energy-ev\": \"%g\",\n", fInterface->anEvent->fStartingEnergies_eV[i]);
-            fprintf(file,"             \"start-radius\": \"%g\",\n", fInterface->anEvent->fRadii[i]);
-            fprintf(file,"             \"start-radial-phase\": \"%g\",\n", fInterface->anEvent->fRadialPhases[i]);
-            fprintf(file,"             \"output-avg-frequency\": \"%g\",\n", fInterface->anEvent->fOutputAvgFrequencies[i]);
-            fprintf(file,"             \"pitch-angle\": \"%.2f\",\n", fInterface->anEvent->fPitchAngles[i]);
-            fprintf(file,"             \"avg-axial-frequency\": \"%g\"\n", fInterface->anEvent->fAvgAxialFrequencies[i]);
+            fprintf(file,"             \"start-time\": %g,\n", fInterface->anEvent->fStartTimes[i]);
+            fprintf(file,"             \"end-time\": %g,\n", fInterface->anEvent->fEndTimes[i]);
+            fprintf(file,"             \"energy-ev\": %g,\n", fInterface->anEvent->fStartingEnergies_eV[i]);
+            fprintf(file,"             \"start-radius\": %g,\n", fInterface->anEvent->fRadii[i]);
+            fprintf(file,"             \"start-radial-phase\": %g,\n", fInterface->anEvent->fRadialPhases[i]);
+            fprintf(file,"             \"output-avg-frequency\": %g,\n", fInterface->anEvent->fOutputAvgFrequencies[i]);
+            fprintf(file,"             \"pitch-angle\": %.2f,\n", fInterface->anEvent->fPitchAngles[i]);
+            fprintf(file,"             \"avg-axial-frequency\": %g\n", fInterface->anEvent->fAvgAxialFrequencies[i]);
             if (i < fInterface->anEvent->fNTracks-1)
             {
                 fprintf(file,"         },\n");

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -56,6 +56,7 @@ namespace locust
             double fConfiguredEMin;
             double fConfiguredPitchMin;
             double fConfiguredXMin;
+            double fConfiguredYMin;
             int fEventCounter;
 
     };

--- a/Source/Kassiopeia/LMCEventHold.hh
+++ b/Source/Kassiopeia/LMCEventHold.hh
@@ -56,6 +56,7 @@ namespace locust
             double fConfiguredEMin;
             double fConfiguredPitchMin;
             double fConfiguredXMin;
+            int fEventCounter;
 
     };
 

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -14,6 +14,7 @@
 
 #include <csignal>
 
+
 using namespace katrin;
 namespace locust
 {
@@ -191,7 +192,7 @@ namespace locust
                 }
                 else
                 {
-                	KRandom::GetInstance().SetSeed(time(NULL));
+                    GetSeed( aParam );
                 }
 
                 auto tGen = fToolbox.GetAll<Kassiopeia::KSGenerator>();
@@ -337,7 +338,9 @@ namespace locust
         }
         else
         {
-            tSeed = time(NULL);
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            tSeed = tv.tv_usec;
         }
         LPROG(lmclog,"Setting random seed for track length to " << tSeed);
         return tSeed;

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -184,16 +184,14 @@ namespace locust
 		    &&   aParam.has( "ks-starting-energy-min" ) && aParam.has( "ks-starting-energy-max" )
 		    &&   aParam.has( "ks-starting-pitch-min" ) && aParam.has( "ks-starting-pitch-max" ) )
             {
-                int tSeed = 0;
-                if ( aParam.has( "random-track-seed" ) )
-                {
-                    tSeed = aParam["random-track-seed"]().as_int();
-                	KRandom::GetInstance().SetSeed(tSeed);
-                }
-                else
-                {
-                	KRandom::GetInstance().SetSeed( GetSeed( aParam ));
-                }
+                int tSeed = GetSeed( aParam );
+                KRandom::GetInstance().SetSeed(tSeed);
+#ifdef ROOT_FOUND
+                fInterface->aRunParameter->fKassiopeiaSeed = tSeed;
+#endif
+
+                LPROG(lmclog,"Setting Kass random seed to " << tSeed);
+
 
                 auto tGen = fToolbox.GetAll<Kassiopeia::KSGenerator>();
                 for (unsigned i=0; i<tGen.size(); i++)
@@ -342,7 +340,6 @@ namespace locust
             gettimeofday(&tv, NULL);
             tSeed = tv.tv_usec;
         }
-        LPROG(lmclog,"Setting random seed for track length to " << tSeed);
         return tSeed;
     }
 
@@ -387,10 +384,15 @@ namespace locust
                     scarab::param_node default_setting;
                     default_setting.add("name","uniform");
                     fTrackLengthDistribution = fDistributionInterface.get_dist(default_setting);
-                    fDistributionInterface.SetSeed( GetSeed(aParam) );
+                    int tSeed = GetSeed( aParam );
+                    fDistributionInterface.SetSeed( tSeed );
                     double tMinTrackLength = tMaxTrackLength * fMinTrackLengthFraction;
                     double tRandomTime = tMinTrackLength + (tMaxTrackLength - tMinTrackLength) * fTrackLengthDistribution->Generate();
                     fLocustMaxTimeTerminator->SetTime( tRandomTime );
+                    LPROG(lmclog,"Random seed for track length is " << tSeed);
+#ifdef ROOT_FOUND
+                    fInterface->aRunParameter->fTrackLengthSeed = tSeed;
+#endif
                     LPROG(lmclog,"Randomizing the track length to " << tRandomTime);
                 }
             }

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -192,7 +192,7 @@ namespace locust
                 }
                 else
                 {
-                    GetSeed( aParam );
+                	KRandom::GetInstance().SetSeed( GetSeed( aParam ));
                 }
 
                 auto tGen = fToolbox.GetAll<Kassiopeia::KSGenerator>();

--- a/Source/Kassiopeia/LMCTrackHold.cc
+++ b/Source/Kassiopeia/LMCTrackHold.cc
@@ -65,10 +65,19 @@ namespace locust
     {
 #ifdef ROOT_FOUND
         fInterface->aTrack->Initialize();
+        if ( fInterface->anEvent->fNTracks > 0 )
+        {
+            // Ongoing event
+            fInterface->aTrack->TrackID = fTrackCounter;
+        }
+        else
+        {
+            // New event starting
+            fTrackCounter = 0;
+        }
 #endif
         fInterface->fNewTrackStarting = true;
         double tTime = aTrack.GetInitialParticle().GetTime();
-
         double tPitchAngle = aTrack.GetInitialParticle().GetPolarAngleToB();
         LWARN(lmclog,"LMCTrack " << fTrackCounter << " is starting at Kass time " << tTime << " with instantaneous pitch angle " <<  tPitchAngle);
         return true;
@@ -79,14 +88,13 @@ namespace locust
         if ( aTrack.GetTotalSteps() > 0)
         {
 #ifdef ROOT_FOUND
-        	fInterface->aTrack->TrackID = fTrackCounter;
             fInterface->anEvent->AddTrack( fInterface->aTrack );
-#endif
+            double tTime = aTrack.GetFinalParticle().GetTime();
+            LWARN(lmclog,"LMCTrack " << fTrackCounter << " is complete at Kass time " << tTime << " with total steps " << aTrack.GetTotalSteps() );
             fTrackCounter += 1;
+#endif
         }
 
-        double tTime = aTrack.GetFinalParticle().GetTime();
-        LWARN(lmclog,"LMCTrack " << fTrackCounter << " is complete at Kass time " << tTime << " with total steps " << aTrack.GetTotalSteps() );
         return true;
     }
 


### PR DESCRIPTION
This pull request includes two changes:  If a random seed is not configured, the internal random seed is now generated in microseconds instead of seconds.  This allows for arrays of hpc jobs to be randomized independently.