### PR TITLE
Feature/unique tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.2 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 3.2.5)
+project( locust_mc VERSION 3.2.6)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -218,8 +218,12 @@ namespace locust
 #ifdef ROOT_FOUND
         if (bNewRun)  // If there are no run parameters in the json file yet, write them now:
         {
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            int tMillisec = int( tv.tv_usec / 1000);
+
             fprintf(file, "{\n");
-            fprintf(file, "    \"run-id\": \"%ld\",\n", fInterface->aRunParameter->fRunID);
+            fprintf(file, "    \"run-id\": \"%ld-%03d\",\n", fInterface->aRunParameter->fRunID, tMillisec);
             fprintf(file, "    \"run-parameters\": {\n");
             fprintf(file, "        \"run-type\": \"%s\",\n", fInterface->aRunParameter->fDataType.c_str());
             fprintf(file, "        \"simulation-type\": \"%s\",\n", fInterface->aRunParameter->fSimulationType.c_str());


### PR DESCRIPTION
Expand the run-id tag, presently based on a microsecond date/time stamp recorded at the beginning of a run.  With this minor change, a ms time stamp will be appended at the end of the run.  The goal is to generate a unique tag for each run.