### PR TITLE
feature/alternateConfigs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop, feature/alternateConfigs]
+    branches: [master, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and Test Locust
 on:
   pull_request:
   push:
-    branches: [master, develop]
+    branches: [master, develop, feature/alternateConfigs]
     tags: ['*']
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.2 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 3.2.7)
+project( locust_mc VERSION 3.2.8)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/IO/LMCRunParameters.hh
+++ b/Source/IO/LMCRunParameters.hh
@@ -36,7 +36,7 @@ namespace locust
             std::string fSimulationType;
             std::string fSimulationSubType;
             long int fRunID;
-            int fKassiopeiaSeed;
+            long int fKassiopeiaSeed;
             int fTrackLengthSeed;
             int fTrackDelaySeed;
 

--- a/Source/Kassiopeia/LMCEventHold.cc
+++ b/Source/Kassiopeia/LMCEventHold.cc
@@ -265,7 +265,7 @@ namespace locust
 
         fprintf(file,"    \"%d\": {\n", fEventCounter);
         fprintf(file,"        \"event-tag\": \"%ld\",\n", fInterface->anEvent->fEventID);
-        fprintf(file,"        \"kassiopeia-seed\": %d,\n", fInterface->aRunParameter->fKassiopeiaSeed);
+        fprintf(file,"        \"kassiopeia-seed\": %ld,\n", fInterface->aRunParameter->fKassiopeiaSeed);
         fprintf(file,"        \"track-length-seed\": %d,\n", fInterface->aRunParameter->fTrackLengthSeed);
         fprintf(file,"        \"track-delay-seed\": %d,\n", fInterface->aRunParameter->fTrackDelaySeed);
         fprintf(file,"        \"ntracks\": %d,\n", fInterface->anEvent->fNTracks);

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -339,6 +339,7 @@ namespace locust
         double cycFrequency = tKassParticleXP[7];
         double tTime = tKassParticleXP[9];
         double amplitude = 0.;
+        int modeSignThetaComp = 1 - 2 * ( fInterface->fField->GetNormalizedModeField(l,m,n,tKassParticleXP,0,bTE)[1] < 0. );
         if ( fInterface->fField->InVolume(tKassParticleXP))
         {
             amplitude = 1.;
@@ -383,7 +384,9 @@ namespace locust
             convolutionPhase = 0.;
         }
 
-        return std::make_pair(convolutionMag*LMCConst::Q()*vMag, convolutionPhase);
+        // Select sign of driven mode amplitude with modeSignThetaComp factor.
+        // This affects modes with n > 1, such as TE012.  It doesn't affect TE011.
+        return std::make_pair(modeSignThetaComp * convolutionMag*LMCConst::Q()*vMag, convolutionPhase);
 
     }
 

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -227,7 +227,13 @@ namespace locust
                     if (aParam["ks-generator"]().as_string() == "ksgen-krypton")
                     {
                         if ( fGenEnergyCreator == nullptr ) fGenEnergyCreator = new Kassiopeia::KSGenEnergyComposite();
-                        if ( fEnergyKrypton == nullptr) fEnergyKrypton = new Kassiopeia::KSGenEnergyKryptonEvent();
+                        if ( fEnergyKrypton == nullptr)
+                        {
+                            fEnergyKrypton = new Kassiopeia::KSGenEnergyKryptonEvent();
+                            fEnergyKrypton->SetDoAuger(false);
+                            fEnergyKrypton->SetForceConversion(true);
+                            fEnergyKrypton->SetDoConversion(true);
+                        }
                         fGenEnergyCreator = fEnergyKrypton;
                         LPROG(lmclog,"Running the krypton energy generator.");
                     }

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -188,7 +188,7 @@ namespace locust
 		    &&   aParam.has( "ks-starting-energy-min" ) && aParam.has( "ks-starting-energy-max" )
 		    &&   aParam.has( "ks-starting-pitch-min" ) && aParam.has( "ks-starting-pitch-max" ) )
             {
-                int tSeed = GetSeed( aParam );
+                long int tSeed = GetSeed( aParam );
                 KRandom::GetInstance().SetSeed(tSeed);
 #ifdef ROOT_FOUND
                 fInterface->aRunParameter->fKassiopeiaSeed = tSeed;
@@ -355,18 +355,26 @@ namespace locust
     }
 
 
-    int RunPause::GetSeed( const scarab::param_node& aParam )
+    long int RunPause::GetSeed( const scarab::param_node& aParam )
     {
-        int tSeed = 0;
+        long int tSeed1 = 0;
+        long int tSeed2 = 0;
+        long int tSeed = 0;
         if ( aParam.has( "random-track-seed" ) )
         {
             tSeed = aParam["random-track-seed"]().as_int();
         }
         else
         {
-            struct timeval tv;
-            gettimeofday(&tv, NULL);
-            tSeed = tv.tv_usec;
+            struct timeval tv1;
+            gettimeofday(&tv1, NULL);
+            tSeed1 = tv1.tv_usec;
+
+            struct timeval tv2;
+            gettimeofday(&tv2, NULL);
+            tSeed2 = tv2.tv_usec;
+
+            tSeed = tSeed1 + 1e7*tSeed2;
         }
         return tSeed;
     }
@@ -412,7 +420,7 @@ namespace locust
                     scarab::param_node default_setting;
                     default_setting.add("name","uniform");
                     fTrackLengthDistribution = fDistributionInterface.get_dist(default_setting);
-                    int tSeed = GetSeed( aParam );
+                    int tSeed = abs(GetSeed( aParam ));
                     fDistributionInterface.SetSeed( tSeed );
                     double tMinTrackLength = tMaxTrackLength * fMinTrackLengthFraction;
                     double tRandomTime = tMinTrackLength + (tMaxTrackLength - tMinTrackLength) * fTrackLengthDistribution->Generate();

--- a/Source/Kassiopeia/LMCRunPause.cc
+++ b/Source/Kassiopeia/LMCRunPause.cc
@@ -36,10 +36,13 @@ namespace locust
 		fGenDirectionComposite( nullptr ),
 		fThetaGenerator( nullptr ),
 		fPhiGenerator( nullptr ),
-		fGenPositionComposite( nullptr ),
+		fGenPositionRectangularComposite( nullptr ),
+		fGenPositionCylindricalComposite( nullptr ),
 		fPositionXGenerator( nullptr ),
 		fPositionYGenerator( nullptr ),
 		fPositionZGenerator( nullptr ),
+		fPositionRadiusGenerator( nullptr ),
+		fPositionPhiGenerator( nullptr ),
 		fGenEnergyComposite( nullptr ),
 		fEnergyUniform( nullptr ),
 		fEnergyKrypton( nullptr ),
@@ -70,10 +73,13 @@ namespace locust
 		fGenDirectionComposite( nullptr ),
 		fThetaGenerator( nullptr ),
 		fPhiGenerator( nullptr ),
-		fGenPositionComposite( nullptr ),
+		fGenPositionRectangularComposite( nullptr ),
+		fGenPositionCylindricalComposite( nullptr ),
 		fPositionXGenerator( nullptr ),
 		fPositionYGenerator( nullptr ),
 		fPositionZGenerator( nullptr ),
+		fPositionRadiusGenerator( nullptr ),
+		fPositionPhiGenerator( nullptr ),
 		fGenEnergyComposite( nullptr ),
 		fEnergyUniform( nullptr ),
 		fEnergyKrypton( nullptr ),
@@ -158,7 +164,7 @@ namespace locust
                 }
             }
 
-            if ( aParam.has( "ks-starting-xpos-min" )  )
+            if ( aParam.has( "ks-starting-zpos-min" ) )
             {
                 if (!AddGenerator( aParam ))
                 {
@@ -176,97 +182,19 @@ namespace locust
 
      }
 
-    bool RunPause::AddGenerator( const scarab::param_node& aParam )
+    bool RunPause::HaveStartingPositions( const scarab::param_node& aParam )
     {
+        if ((  aParam.has( "ks-starting-xpos-min" ) && aParam.has( "ks-starting-xpos-max" )
+          &&   aParam.has( "ks-starting-ypos-min" ) && aParam.has( "ks-starting-ypos-max" )
+          &&   aParam.has( "ks-starting-zpos-min" ) && aParam.has( "ks-starting-zpos-max" )
+          && !( aParam.has( "ks-starting-rpos-min" ) || aParam.has( "ks-starting-rpos-max" )
+            ||  aParam.has( "ks-starting-phipos-min" ) || aParam.has( "ks-starting-phipos-max" )
+	          ) )
 
-        if (!fToolbox.HasKey("gen_project8"))
-        {
-
-            if ( aParam.has( "ks-starting-xpos-min" ) && aParam.has( "ks-starting-xpos-max" )
-            &&   aParam.has( "ks-starting-ypos-min" ) && aParam.has( "ks-starting-ypos-max" )
-		    &&   aParam.has( "ks-starting-zpos-min" ) && aParam.has( "ks-starting-zpos-max" )
-		    &&   aParam.has( "ks-starting-energy-min" ) && aParam.has( "ks-starting-energy-max" )
-		    &&   aParam.has( "ks-starting-pitch-min" ) && aParam.has( "ks-starting-pitch-max" ) )
+        )
             {
-                long int tSeed = GetSeed( aParam );
-                KRandom::GetInstance().SetSeed(tSeed);
-#ifdef ROOT_FOUND
-                fInterface->aRunParameter->fKassiopeiaSeed = tSeed;
-#endif
-
-                LPROG(lmclog,"Setting Kass random seed to " << tSeed);
-
-
-                auto tGen = fToolbox.GetAll<Kassiopeia::KSGenerator>();
-                for (unsigned i=0; i<tGen.size(); i++)
-                {
-                    if ( (tGen[i]->IsActivated()) &&  (tGen[i]->GetName()!="root_generator") )
-                    {
-                        LPROG(lmclog,"Clearing " << tGen[i]->GetName() << " from KSRoot ... ");
-                        fToolbox.Get<Kassiopeia::KSRootGenerator>("root_generator")->ClearGenerator(tGen[i]);
-                        tGen[i]->RemoveTags(tGen[i]->GetTags());
-                        tGen[i]->Deactivate();
-                        tGen[i]->Deinitialize();
-                        fToolbox.Remove(tGen[i]->GetName());
-                    }
-                }
-
-                if ( fGenPidComposite == nullptr ) fGenPidComposite = new Kassiopeia::KSGenValueFix();
-                fGenPidComposite->SetValue(11); // electron
-
-                if ( fGenTimeComposite == nullptr ) fGenTimeComposite = new Kassiopeia::KSGenTimeComposite();
-                if ( fTimeGenerator == nullptr ) fTimeGenerator = new Kassiopeia::KSGenValueUniform();
-                fTimeGenerator->SetValueMin(0.);
-                fTimeGenerator->SetValueMax(0.);
-                fGenTimeComposite->SetTimeValue(fTimeGenerator);
-
-
-                if ( fGenEnergyComposite == nullptr ) fGenEnergyComposite = new Kassiopeia::KSGenEnergyComposite();
-                if ( aParam.has( "ks-generator" ) )
-                {
-                    if (aParam["ks-generator"]().as_string() == "ksgen-krypton")
-                    {
-                        if ( fGenEnergyCreator == nullptr ) fGenEnergyCreator = new Kassiopeia::KSGenEnergyComposite();
-                        if ( fEnergyKrypton == nullptr)
-                        {
-                            fEnergyKrypton = new Kassiopeia::KSGenEnergyKryptonEvent();
-                            fEnergyKrypton->SetDoAuger(false);
-                            fEnergyKrypton->SetForceConversion(true);
-                            fEnergyKrypton->SetDoConversion(true);
-                        }
-                        fGenEnergyCreator = fEnergyKrypton;
-                        LPROG(lmclog,"Running the krypton energy generator.");
-                    }
-                    else
-                    {
-                    	LERROR(lmclog,"Kassiopeia generator not found.  "
-                    			"Remove \"ks-generator\" from the Locust config file to default to \"ksgen-uniform\"  ");
-                    	return false;
-                    }
-                }
-                else
-                {
-                    if ( fGenEnergyCreator == nullptr ) fGenEnergyCreator = new Kassiopeia::KSGenEnergyComposite();
-                    if ( fEnergyUniform == nullptr ) fEnergyUniform = new Kassiopeia::KSGenValueUniform();
-                    if ( aParam.has( "ks-starting-energy-min" ) && ( aParam.has( "ks-starting-energy-max" ) ) )
-                    {
-                        fEnergyUniform->SetValueMin( aParam["ks-starting-energy-min"]().as_double() ); // eV
-                        fEnergyUniform->SetValueMax( aParam["ks-starting-energy-max"]().as_double() ); // eV
-                    }
-                    else
-                    {
-                        fEnergyUniform->SetValueMin( 18600. ); // eV
-                        fEnergyUniform->SetValueMax( 18600. ); // eV
-                    }
-                    fGenEnergyComposite->SetEnergyValue(fEnergyUniform);
-                    fGenEnergyCreator = fGenEnergyComposite;
-                    LPROG(lmclog,"Running the uniform energy generator.");
-                }
-
-
-
-                if ( fGenPositionComposite == nullptr ) fGenPositionComposite = new Kassiopeia::KSGenPositionRectangularComposite();
-                fGenPositionComposite->SetOrigin(GetKGWorldSpace()->GetOrigin());
+                if ( fGenPositionRectangularComposite == nullptr ) fGenPositionRectangularComposite = new Kassiopeia::KSGenPositionRectangularComposite();
+                fGenPositionRectangularComposite->SetOrigin(GetKGWorldSpace()->GetOrigin());
                 if ( fPositionXGenerator == nullptr ) fPositionXGenerator = new Kassiopeia::KSGenValueUniform();
                 if ( fPositionYGenerator == nullptr ) fPositionYGenerator = new Kassiopeia::KSGenValueUniform();
                 if ( fPositionZGenerator == nullptr ) fPositionZGenerator = new Kassiopeia::KSGenValueUniform();
@@ -276,32 +204,179 @@ namespace locust
                 fPositionYGenerator->SetValueMax( aParam["ks-starting-ypos-max"]().as_double() );
                 fPositionZGenerator->SetValueMin( aParam["ks-starting-zpos-min"]().as_double() );
                 fPositionZGenerator->SetValueMax( aParam["ks-starting-zpos-max"]().as_double() );
-                fGenPositionComposite->SetXValue(fPositionXGenerator);
-                fGenPositionComposite->SetYValue(fPositionYGenerator);
-                fGenPositionComposite->SetZValue(fPositionZGenerator);
+                fGenPositionRectangularComposite->SetXValue(fPositionXGenerator);
+                fGenPositionRectangularComposite->SetYValue(fPositionYGenerator);
+                fGenPositionRectangularComposite->SetZValue(fPositionZGenerator);
+                return true;
+            }
+        else if ( aParam.has( "ks-starting-rpos-min" ) && aParam.has( "ks-starting-rpos-max" )
+              &&  aParam.has( "ks-starting-phipos-min" ) && aParam.has( "ks-starting-phipos-max" )
+              &&  aParam.has( "ks-starting-zpos-min" ) && aParam.has( "ks-starting-zpos-max" )
+              && !( aParam.has( "ks-starting-xpos-min" ) || aParam.has( "ks-starting-xpos-max" )
+                ||  aParam.has( "ks-starting-ypos-min" ) || aParam.has( "ks-starting-ypos-max" ))
+                )
+        {
+            if ( fGenPositionCylindricalComposite == nullptr ) fGenPositionCylindricalComposite = new Kassiopeia::KSGenPositionCylindricalComposite();
+            fGenPositionCylindricalComposite->SetOrigin(GetKGWorldSpace()->GetOrigin());
+            if ( fPositionRadiusGenerator == nullptr ) fPositionRadiusGenerator = new Kassiopeia::KSGenValueRadiusCylindrical();
+            if ( fPositionPhiGenerator == nullptr ) fPositionPhiGenerator = new Kassiopeia::KSGenValueUniform();
+            if ( fPositionZGenerator == nullptr ) fPositionZGenerator = new Kassiopeia::KSGenValueUniform();
+            fPositionRadiusGenerator->SetRadiusMin( aParam["ks-starting-rpos-min"]().as_double() ); // meters
+            fPositionRadiusGenerator->SetRadiusMax( aParam["ks-starting-rpos-max"]().as_double() );
+            fPositionPhiGenerator->SetValueMin( aParam["ks-starting-phipos-min"]().as_double() );
+            fPositionPhiGenerator->SetValueMax( aParam["ks-starting-phipos-max"]().as_double() );
+            fPositionZGenerator->SetValueMin( aParam["ks-starting-zpos-min"]().as_double() );
+            fPositionZGenerator->SetValueMax( aParam["ks-starting-zpos-max"]().as_double() );
+            fGenPositionCylindricalComposite->SetRValue(fPositionRadiusGenerator);
+            fGenPositionCylindricalComposite->SetPhiValue(fPositionPhiGenerator);
+            fGenPositionCylindricalComposite->SetZValue(fPositionZGenerator);
 
-                if ( fGenDirectionComposite == nullptr ) fGenDirectionComposite = new Kassiopeia::KSGenDirectionSphericalComposite();
-                if ( fThetaGenerator == nullptr ) fThetaGenerator = new Kassiopeia::KSGenValueAngleSpherical();
-                fThetaGenerator->SetAngleMin( aParam["ks-starting-pitch-min"]().as_double() );
-                fThetaGenerator->SetAngleMax( aParam["ks-starting-pitch-max"]().as_double() );
-                if ( fPhiGenerator == nullptr ) fPhiGenerator = new Kassiopeia::KSGenValueUniform();
-                if ( aParam.has( "ks-starting-phi-min" ) && ( aParam.has( "ks-starting-phi-max" ) ) )
+            return true;
+        }
+        else
+        {
+            LERROR(lmclog,"Either some of the Kass position parameters are missing from "
+            		"the config file, or there is a mixture of Cartesian and polar coordinates.");
+            exit(-1);
+        	return false;
+        }
+    }
+
+    bool RunPause::HaveGenConfigParams( const scarab::param_node& aParam )
+    {
+        if ( aParam.has( "ks-starting-energy-min" ) && aParam.has( "ks-starting-energy-max" )
+          && aParam.has( "ks-starting-pitch-min" ) && aParam.has( "ks-starting-pitch-max" ) )
+        {
+            return true;
+        }
+        else
+        {
+            LERROR(lmclog,"Some of the Kass kinetic parameters are missing from the config file.");
+            return false;
+        }
+    }
+
+    bool RunPause::SetupGenerator( const scarab::param_node& aParam )
+    {
+        auto tGen = fToolbox.GetAll<Kassiopeia::KSGenerator>();
+        for (unsigned i=0; i<tGen.size(); i++)
+        {
+            if ( (tGen[i]->IsActivated()) &&  (tGen[i]->GetName()!="root_generator") )
+            {
+                LPROG(lmclog,"Clearing " << tGen[i]->GetName() << " from KSRoot ... ");
+                fToolbox.Get<Kassiopeia::KSRootGenerator>("root_generator")->ClearGenerator(tGen[i]);
+                tGen[i]->RemoveTags(tGen[i]->GetTags());
+                tGen[i]->Deactivate();
+                tGen[i]->Deinitialize();
+                fToolbox.Remove(tGen[i]->GetName());
+            }
+        }
+
+        if ( fGenPidComposite == nullptr ) fGenPidComposite = new Kassiopeia::KSGenValueFix();
+        fGenPidComposite->SetValue(11); // electron
+
+        if ( fGenTimeComposite == nullptr ) fGenTimeComposite = new Kassiopeia::KSGenTimeComposite();
+        if ( fTimeGenerator == nullptr ) fTimeGenerator = new Kassiopeia::KSGenValueUniform();
+        fTimeGenerator->SetValueMin(0.);
+        fTimeGenerator->SetValueMax(0.);
+        fGenTimeComposite->SetTimeValue(fTimeGenerator);
+
+        if ( fGenEnergyComposite == nullptr ) fGenEnergyComposite = new Kassiopeia::KSGenEnergyComposite();
+        if ( fEnergyUniform == nullptr ) fEnergyUniform = new Kassiopeia::KSGenValueUniform();
+        if ( aParam.has( "ks-starting-energy-min" ) && ( aParam.has( "ks-starting-energy-max" ) ) )
+        {
+            fEnergyUniform->SetValueMin( aParam["ks-starting-energy-min"]().as_double() ); // eV
+            fEnergyUniform->SetValueMax( aParam["ks-starting-energy-max"]().as_double() ); // eV
+        }
+        else
+        {
+            fEnergyUniform->SetValueMin( 18600. ); // eV
+            fEnergyUniform->SetValueMax( 18600. ); // eV
+        }
+        fGenEnergyComposite->SetEnergyValue(fEnergyUniform);
+        fGenEnergyCreator = fGenEnergyComposite;
+        LPROG(lmclog,"Running the uniform energy generator.");
+
+        if ( aParam.has( "ks-generator" ) )
+        {
+            if (aParam["ks-generator"]().as_string() == "ksgen-uniform")
+            {
+                LPROG(lmclog,"Confirming default uniform energy generator.");
+            }
+
+            else if (aParam["ks-generator"]().as_string() == "ksgen-krypton")
+            {
+                fGenEnergyCreator = nullptr;
+                if ( fGenEnergyCreator == nullptr ) fGenEnergyCreator = new Kassiopeia::KSGenEnergyComposite();
+                if ( fEnergyKrypton == nullptr)
                 {
-                    fPhiGenerator->SetValueMin( aParam["ks-starting-phi-min"]().as_double() );
-                    fPhiGenerator->SetValueMax( aParam["ks-starting-phi-max"]().as_double() );
+                    fEnergyKrypton = new Kassiopeia::KSGenEnergyKryptonEvent();
+                    fEnergyKrypton->SetDoAuger(false);
+                    fEnergyKrypton->SetForceConversion(true);
+                    fEnergyKrypton->SetDoConversion(true);
                 }
-                else
-                {
-                    fPhiGenerator->SetValueMin( 0. );
-                    fPhiGenerator->SetValueMax( 0. );
-                }
-                fGenDirectionComposite->SetPhiValue(fPhiGenerator);
-                fGenDirectionComposite->SetThetaValue(fThetaGenerator);
+                fGenEnergyCreator = fEnergyKrypton;
+                LPROG(lmclog,"Running the krypton energy generator.");
+            }
+        }
+
+        return true;
+
+    }
+
+    bool RunPause::SetupDirection( const scarab::param_node& aParam )
+    {
+        if ( fGenDirectionComposite == nullptr ) fGenDirectionComposite = new Kassiopeia::KSGenDirectionSphericalComposite();
+        if ( fThetaGenerator == nullptr ) fThetaGenerator = new Kassiopeia::KSGenValueAngleSpherical();
+        fThetaGenerator->SetAngleMin( aParam["ks-starting-pitch-min"]().as_double() );
+        fThetaGenerator->SetAngleMax( aParam["ks-starting-pitch-max"]().as_double() );
+        if ( fPhiGenerator == nullptr ) fPhiGenerator = new Kassiopeia::KSGenValueUniform();
+        if ( aParam.has( "ks-starting-phi-min" ) && ( aParam.has( "ks-starting-phi-max" ) ) )
+        {
+            fPhiGenerator->SetValueMin( aParam["ks-starting-phi-min"]().as_double() );
+            fPhiGenerator->SetValueMax( aParam["ks-starting-phi-max"]().as_double() );
+        }
+        else
+        {
+            fPhiGenerator->SetValueMin( 0. );
+            fPhiGenerator->SetValueMax( 0. );
+        }
+        fGenDirectionComposite->SetPhiValue(fPhiGenerator);
+        fGenDirectionComposite->SetThetaValue(fThetaGenerator);
+
+        return true;
+    }
+
+    bool RunPause::AddGenerator( const scarab::param_node& aParam )
+    {
+
+        if (!fToolbox.HasKey("gen_project8"))
+        {
+
+            if ( HaveStartingPositions( aParam ) && HaveGenConfigParams( aParam ) )
+            {
+                long int tSeed = GetSeed( aParam );
+                KRandom::GetInstance().SetSeed(tSeed);
+#ifdef ROOT_FOUND
+                fInterface->aRunParameter->fKassiopeiaSeed = tSeed;
+#endif
+
+                LPROG(lmclog,"Setting Kass random seed to " << tSeed);
+
+                SetupGenerator( aParam );
+                SetupDirection( aParam );
 
                 if ( fGenerator == nullptr ) fGenerator = new Kassiopeia::KSGenGeneratorComposite();
 
                 fGenerator->SetPid(fGenPidComposite);
-                fGenerator->AddCreator(fGenPositionComposite);
+                if ( aParam.has( "ks-starting-xpos-min" ) )
+                {
+                    fGenerator->AddCreator(fGenPositionRectangularComposite);
+                }
+                else
+                {
+                    fGenerator->AddCreator(fGenPositionCylindricalComposite);
+                }
                 fGenerator->AddCreator(fGenEnergyCreator);
                 fGenerator->AddCreator(fGenDirectionComposite);
                 fGenerator->AddCreator(fGenTimeComposite);
@@ -316,10 +391,6 @@ namespace locust
 
             else
             {
-                LERROR(lmclog,"To configure starting e- kinematics, all of these parameters are needed:  "
-            	    "ks-starting-xpos-min, ks-starting-xpos-max, ks-starting-ypos-min, ks-starting-ypos-max, "
-            	    "ks-starting-zpos-min, ks-starting-zpos-max, ks-starting-pitch-min, ks-starting-pitch-max,"
-            	    "ks-starting-energy-min, ks-starting-energy-max ");
                 return false;
             }
         }

--- a/Source/Kassiopeia/LMCRunPause.hh
+++ b/Source/Kassiopeia/LMCRunPause.hh
@@ -62,7 +62,7 @@ namespace locust
             bool AddMaxTimeTerminator( const scarab::param_node& aParam );
             bool AddMaxRTerminator( const scarab::param_node& aParam );
             bool AddGenerator( const scarab::param_node& aParam );
-            int GetSeed( const scarab::param_node& aParam );
+            long int GetSeed( const scarab::param_node& aParam );
 
 
 

--- a/Source/Kassiopeia/LMCRunPause.hh
+++ b/Source/Kassiopeia/LMCRunPause.hh
@@ -11,6 +11,8 @@
 #include "KSRunModifier.h"
 #include "KToolbox.h"
 #include "KSTermMaxR.h"
+#include "KSTermMaxEnergy.h"
+#include "KSTermMinEnergy.h"
 #include "KSTermMaxTime.h"
 #include "KSTermDeath.h"
 #include "KSRootTerminator.h"
@@ -62,6 +64,7 @@ namespace locust
             bool DeleteLocalKassObjects();
             bool AddWaveguideTerminator( const scarab::param_node& aParam );
             bool AddMaxTimeTerminator( const scarab::param_node& aParam );
+            bool AddEnergyTerminators( const scarab::param_node& aParam );
             bool AddMaxRTerminator( const scarab::param_node& aParam );
             bool AddGenerator( const scarab::param_node& aParam );
             bool HaveStartingPositions( const scarab::param_node& aParam );
@@ -80,6 +83,8 @@ namespace locust
             katrin::KToolbox& fToolbox;
             Kassiopeia::KSTermMaxTime* fLocustMaxTimeTerminator;
             Kassiopeia::KSTermMaxR* fLocustMaxRTerminator;
+            Kassiopeia::KSTermMaxEnergy* fLocustMaxEnergyTerminator;
+            Kassiopeia::KSTermMinEnergy* fLocustMinEnergyTerminator;
             KGeoBag::KGBoxSpace* fBox;
             KGeoBag::KGSpace* fKGSpace;
             Kassiopeia::KSGeoSurface* fSurface;

--- a/Source/Kassiopeia/LMCRunPause.hh
+++ b/Source/Kassiopeia/LMCRunPause.hh
@@ -22,10 +22,12 @@
 #include "KSGenGeneratorComposite.h"
 #include "KSGenValueUniform.h"
 #include "KSGenValueAngleSpherical.h"
+#include "KSGenValueRadiusCylindrical.h"
 #include "KSGenValueFix.h"
 #include "KSGenEnergyComposite.h"
 #include "KSGenEnergyKryptonEvent.h"
 #include "KSGenPositionRectangularComposite.h"
+#include "KSGenPositionCylindricalComposite.h"
 #include "KSGenDirectionSphericalComposite.h"
 #include "KSGenTimeComposite.h"
 #include "LMCKassLocustInterface.hh"
@@ -62,6 +64,10 @@ namespace locust
             bool AddMaxTimeTerminator( const scarab::param_node& aParam );
             bool AddMaxRTerminator( const scarab::param_node& aParam );
             bool AddGenerator( const scarab::param_node& aParam );
+            bool HaveStartingPositions( const scarab::param_node& aParam );
+            bool HaveGenConfigParams( const scarab::param_node& aParam );
+            bool SetupGenerator( const scarab::param_node& aParam );
+            bool SetupDirection( const scarab::param_node& aParam );
             long int GetSeed( const scarab::param_node& aParam );
 
 
@@ -82,19 +88,22 @@ namespace locust
             Kassiopeia::KSGeoSpace* fKSSpace;
             Kassiopeia::KSGenGeneratorComposite* fGenerator;
             Kassiopeia::KSGenDirectionSphericalComposite* fGenDirectionComposite;
-			Kassiopeia::KSGenValueAngleSpherical* fThetaGenerator;
-			Kassiopeia::KSGenValueUniform* fPhiGenerator;
-			Kassiopeia::KSGenPositionRectangularComposite* fGenPositionComposite;
-			Kassiopeia::KSGenValueUniform* fPositionXGenerator;
-			Kassiopeia::KSGenValueUniform* fPositionYGenerator;
-			Kassiopeia::KSGenValueUniform* fPositionZGenerator;
-			Kassiopeia::KSGenValueUniform* fEnergyUniform;
-			Kassiopeia::KSGenEnergyKryptonEvent* fEnergyKrypton;
-			Kassiopeia::KSGenEnergyComposite* fGenEnergyComposite;
-			Kassiopeia::KSGenCreator* fGenEnergyCreator;
-			Kassiopeia::KSGenTimeComposite* fGenTimeComposite;
-			Kassiopeia::KSGenValueUniform* fTimeGenerator;
-			Kassiopeia::KSGenValueFix* fGenPidComposite;
+            Kassiopeia::KSGenValueAngleSpherical* fThetaGenerator; // pitch angle
+            Kassiopeia::KSGenValueUniform* fPhiGenerator; // orbit phase
+            Kassiopeia::KSGenPositionRectangularComposite* fGenPositionRectangularComposite;
+            Kassiopeia::KSGenPositionCylindricalComposite* fGenPositionCylindricalComposite;
+            Kassiopeia::KSGenValueUniform* fPositionPhiGenerator;
+            Kassiopeia::KSGenValueRadiusCylindrical* fPositionRadiusGenerator;
+            Kassiopeia::KSGenValueUniform* fPositionXGenerator;
+            Kassiopeia::KSGenValueUniform* fPositionYGenerator;
+            Kassiopeia::KSGenValueUniform* fPositionZGenerator;
+            Kassiopeia::KSGenValueUniform* fEnergyUniform;
+            Kassiopeia::KSGenEnergyKryptonEvent* fEnergyKrypton;
+            Kassiopeia::KSGenEnergyComposite* fGenEnergyComposite;
+            Kassiopeia::KSGenCreator* fGenEnergyCreator;
+            Kassiopeia::KSGenTimeComposite* fGenTimeComposite;
+            Kassiopeia::KSGenValueUniform* fTimeGenerator;
+            Kassiopeia::KSGenValueFix* fGenPidComposite;
 
             std::shared_ptr< BaseDistribution> fTrackLengthDistribution;
             DistributionInterface fDistributionInterface;


### PR DESCRIPTION
These changes include minor expansions in configurability:
- signal calculations for modes `lmn` with `n` > 1.
- access to Kass randomizations for uniform starting positions within a cylindrical volume, using pitch angle distributions that are uniform over a sphere segment (screenshot attached for trapped electrons)
- additional configurability in the Kass krypton energy generator; preliminary metadata for trapped 17.8 keV conversion electrons included in screenshot below.
<img width="1828" height="1069" alt="Screenshot from 2025-08-25 11-32-44" src="https://github.com/user-attachments/assets/cef1b6ea-e10f-4bdd-a1f3-880b7fe1ae56" />
