### PR TITLE
hotfix/v3.2.8mode maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.2 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 3.2.8)
+project( locust_mc VERSION 3.2.9)
 
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )

--- a/Source/Kassiopeia/LMCFieldCalculator.cc
+++ b/Source/Kassiopeia/LMCFieldCalculator.cc
@@ -17,6 +17,7 @@ namespace locust
 
     FieldCalculator::FieldCalculator() :
         fNFilterBinsRequired( 0 ),
+        fModeMap( false ),
         fTFReceiverHandler( NULL ),
         fAnalyticResponseFunction( 0 ),
         fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
@@ -24,6 +25,7 @@ namespace locust
     }
     FieldCalculator::FieldCalculator( const FieldCalculator& aCopy ) :
         fNFilterBinsRequired( 0 ),
+        fModeMap( false ),
         fTFReceiverHandler( NULL ),
         fAnalyticResponseFunction( 0 ),
         fInterface( aCopy.fInterface )
@@ -94,6 +96,12 @@ namespace locust
 
         // Size the electron information buffers to be similar to the Green's functions:
         SetFilterSize( fTFReceiverHandler->GetFilterSizeArray(fModeSet[0][0],fModeSet[0][1],fModeSet[0][2],fModeSet[0][3]));
+
+        if( aParam.has( "upload-modemap-filename" ) )
+        {
+            fModeMap = true;
+        }
+
         return true;
     }
 
@@ -339,7 +347,12 @@ namespace locust
         double cycFrequency = tKassParticleXP[7];
         double tTime = tKassParticleXP[9];
         double amplitude = 0.;
-        int modeSignThetaComp = 1 - 2 * ( fInterface->fField->GetNormalizedModeField(l,m,n,tKassParticleXP,0,bTE)[1] < 0. );
+        int modeSignThetaComp = 1;
+        if ( !fModeMap )
+        {
+            modeSignThetaComp = 1 - 2 * ( fInterface->fField->GetNormalizedModeField(l,m,n,tKassParticleXP,0,bTE)[1] < 0. );
+        }
+
         if ( fInterface->fField->InVolume(tKassParticleXP))
         {
             amplitude = 1.;

--- a/Source/Kassiopeia/LMCFieldCalculator.hh
+++ b/Source/Kassiopeia/LMCFieldCalculator.hh
@@ -60,6 +60,7 @@ namespace locust
             std::deque<double> fFIRBuffer;
             std::deque<double> fFrequencyBuffer;
             int fNFilterBinsRequired;
+            bool fModeMap;
             std::vector<std::vector<int>> fModeSet;
     };
 


### PR DESCRIPTION
This fix applies to v3.2.8 when running with imported mode maps.  The mode map functionality was inadvertently affected by a recent change to allow for modes with n>1.