### PR TITLE
Feature/metadata fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required( VERSION 3.2 )
 
 # Define the project
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( locust_mc VERSION 3.5.1)
+project( locust_mc VERSION 3.5.2)
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Scarab/cmake )
 include( PackageBuilder )

--- a/Source/IO/LMCTrack.cc
+++ b/Source/IO/LMCTrack.cc
@@ -43,6 +43,8 @@ namespace locust
         StartGuidingCenterX = -99.;
         StartGuidingCenterY = -99.;
         StartGuidingCenterZ = -99.;
+        NCrossings = 0;
+        T0trapMin = 0.;
 
         return true;
 

--- a/Source/IO/LMCTrack.hh
+++ b/Source/IO/LMCTrack.hh
@@ -50,6 +50,8 @@ namespace locust
             double StartGuidingCenterX = -99.;
             double StartGuidingCenterY = -99.;
             double StartGuidingCenterZ = -99.;
+            int NCrossings = 0;
+            double T0trapMin = 0.;
 
             ClassDef(Track,1)  // Root syntax.
 

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.cc
@@ -12,9 +12,6 @@ namespace locust
     CyclotronRadiationExtractor::CyclotronRadiationExtractor() :
             fNewParticleHistory(),
             fFieldCalculator( NULL ),
-            fPitchAngle( -99. ),
-            fT0trapMin( 0. ),
-            fNCrossings( 0 ),
             fSampleIndex( 0 ),
             fInterface( KLInterfaceBootstrapper::get_instance()->GetInterface() )
     {
@@ -23,9 +20,6 @@ namespace locust
     CyclotronRadiationExtractor::CyclotronRadiationExtractor(const CyclotronRadiationExtractor &aCopy) : KSComponent(),
             fNewParticleHistory(),
             fFieldCalculator( NULL ),
-            fPitchAngle( aCopy.fPitchAngle ),
-            fT0trapMin( aCopy.fT0trapMin ),
-            fNCrossings( aCopy.fNCrossings ),
             fSampleIndex( aCopy.fSampleIndex ),
             fInterface( aCopy.fInterface )
     {
@@ -147,33 +141,28 @@ namespace locust
         aNewParticle.SetCyclotronFrequency(2.*LMCConst::Pi()*tCyclotronFrequency);
         aNewParticle.SetKinematicProperties();
 
-
+#ifdef ROOT_FOUND
         if (anInitialParticle.GetPosition().GetZ()/aFinalParticle.GetPosition().GetZ() < 0.)  // trap center
         {
-            fNCrossings += 1;
-            if (fPitchAngle == -99.)  // first crossing of center
+            fInterface->aTrack->NCrossings += 1;
+            if (fInterface->aTrack->PitchAngle == -99.)  // first crossing of center
             {
-                fPitchAngle = aFinalParticle.GetPolarAngleToB();
-                fT0trapMin = aFinalParticle.GetTime();
-#ifdef ROOT_FOUND
                 fInterface->aTrack->PitchAngle = aFinalParticle.GetPolarAngleToB();
+                fInterface->aTrack->T0trapMin = aFinalParticle.GetTime();
                 fInterface->aTrack->StartFrequency = aFinalParticle.GetCyclotronFrequency();
                 double tLOfrequency = fInterface->aRunParameter->fLOfrequency; // Hz
                 double tSamplingRate = fInterface->aRunParameter->fSamplingRateMHz; // MHz
                 double tOffset = -tLOfrequency + tSamplingRate * 1.e6 / 2.; // Hz
                 fInterface->aTrack->OutputStartFrequency = aFinalParticle.GetCyclotronFrequency() + tOffset; // Hz
-#endif
             }
             else
             {
-#ifdef ROOT_FOUND
                 fInterface->aTrack->EndFrequency = aFinalParticle.GetCyclotronFrequency();
-                fInterface->aTrack->AvgAxialFrequency = fNCrossings / 2. / ( aFinalParticle.GetTime() - fT0trapMin );
-#endif
+                fInterface->aTrack->AvgAxialFrequency = fInterface->aTrack->NCrossings / 2. / ( aFinalParticle.GetTime() - fInterface->aTrack->T0trapMin );
             }
         }
-        aNewParticle.SetPitchAngle(fPitchAngle);
-
+        aNewParticle.SetPitchAngle(fInterface->aTrack->PitchAngle);
+#endif
         return aNewParticle;
 
     }
@@ -230,7 +219,6 @@ namespace locust
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
                 fInterface->fNewTrackStarting = false;
                 aFinalParticle.SetParentTrackId( aFinalParticle.GetParentTrackId() + 1 );
-                fPitchAngle = -99.;  // new track needs central pitch angle reset.
                 double dt = aFinalParticle.GetTime() - anInitialParticle.GetTime();
                 fFieldCalculator->SetNFilterBinsRequired( dt );
                 UpdateTrackProperties( aFinalParticle, fInterface->fSampleIndex, 1 );

--- a/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
+++ b/Source/Kassiopeia/LMCCyclotronRadiationExtractor.hh
@@ -56,9 +56,6 @@ namespace locust
 
         private:
             std::deque<locust::Particle> fNewParticleHistory;
-            double fPitchAngle;
-            double fT0trapMin;
-            int fNCrossings;
             FieldCalculator* fFieldCalculator;
             kl_interface_ptr_t fInterface;
             unsigned fSampleIndex;


### PR DESCRIPTION
When running Locust-Kass with scattering activated in Kassiopeia, a bug was found in the recorded truth information (metadata) from Locust.  The following quantity was not being recorded correctly:

Average axial frequency of the electron in tracks that follow the first scatter.

A fix has been implemented so that the relevant track properties are now correctly initialized between tracks.  Thank you to @juniorpena for noticing this.